### PR TITLE
Add asciinema demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 This repository contains a tool to communicate with the [Parsec
 service](https://github.com/parallaxsecond/parsec) on the command-line.
 
+# Demo
+
+[![asciicast](https://asciinema.org/a/bGRK4lFZnCq3UZQSWa7vQfuT5.svg)](https://asciinema.org/a/bGRK4lFZnCq3UZQSWa7vQfuT5)
+
 ## License
 
 The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.


### PR DESCRIPTION
Hey guys,

I've added an `asciinema` demo to the repository, as suggested in issue #2. The demo video is linked below:

[![asciicast](https://asciinema.org/a/352154.svg)](https://asciinema.org/a/352154)

You can, of course, see how this looks in the context of the `README.md` file by taking a look at my fork. 😄 

Cheers!