### PR TITLE
List providers UUID fix

### DIFF
--- a/src/subcommands/list_providers.rs
+++ b/src/subcommands/list_providers.rs
@@ -58,7 +58,7 @@ impl ParsecToolSubcommand for ListProvidersSubcommand {
                         "Unspecified".to_string()
                     },
                 );
-                field!("Vendor", "{}", provider.uuid);
+                field!("UUID", "{}", provider.uuid);
                 println!();
             }
             Ok(())


### PR DESCRIPTION
We now label the field as 'UUID', as we should.