### PR TITLE
Refactor `ParsecToolSubcommand` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
     unused_import_braces,
     unused_qualifications,
     unused_results,
-    missing_copy_implementations
 )]
 // This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]

--- a/src/subcommands/common.rs
+++ b/src/subcommands/common.rs
@@ -7,7 +7,7 @@ use structopt::StructOpt;
 
 /// Options for specifying a provider. Most, but not all subcommands require the user to do this,
 /// so it's useful to have these options shared.
-#[derive(Copy, Clone, Debug, StructOpt)]
+#[derive(Debug, StructOpt)]
 pub struct ProviderOpts {
     /// The provider to list opcodes for.
     #[structopt(short = "p", long = "provider", default_value = "0")]

--- a/src/subcommands/list_opcodes.rs
+++ b/src/subcommands/list_opcodes.rs
@@ -15,17 +15,17 @@ use std::convert::TryFrom;
 use structopt::StructOpt;
 
 /// Lists the supported opcodes for a given provider.
-#[derive(Copy, Clone, Debug, StructOpt)]
+#[derive(Debug, StructOpt)]
 #[structopt(name = "list_opcodes")]
 pub struct ListOpcodesSubcommand {
     #[structopt(flatten)]
     provider_opts: ProviderOpts,
 }
 
-impl TryFrom<ListOpcodesSubcommand> for NativeOperation {
+impl TryFrom<&ListOpcodesSubcommand> for NativeOperation {
     type Error = ParsecToolError;
 
-    fn try_from(list_opcodes_subcommand: ListOpcodesSubcommand) -> Result<Self, Self::Error> {
+    fn try_from(list_opcodes_subcommand: &ListOpcodesSubcommand) -> Result<Self, Self::Error> {
         // Trivially converted to a `NativeOperation`.
         Ok(NativeOperation::ListOpcodes(list_opcodes::Operation {
             provider_id: ProviderID::try_from(list_opcodes_subcommand.provider_opts.provider)?,
@@ -33,12 +33,12 @@ impl TryFrom<ListOpcodesSubcommand> for NativeOperation {
     }
 }
 
-impl ParsecToolSubcommand for ListOpcodesSubcommand {
+impl ParsecToolSubcommand<'_> for ListOpcodesSubcommand {
     /// Lists the supported opcodes for a given provider.
     fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
-            NativeOperation::try_from(*self)?,
+            NativeOperation::try_from(self)?,
             // We still use the core provider beacuse listing opcodes is a core operation. Note the
             // distinction between the provider we're _using_ and the provider we're querying.
             ProviderID::Core,

--- a/src/subcommands/list_providers.rs
+++ b/src/subcommands/list_providers.rs
@@ -14,25 +14,25 @@ use std::convert::TryFrom;
 use structopt::StructOpt;
 
 /// Lists the available providers supported by the Parsec service.
-#[derive(Copy, Clone, Debug, StructOpt)]
+#[derive(Debug, StructOpt)]
 #[structopt(name = "list_providers")]
 pub struct ListProvidersSubcommand {}
 
-impl TryFrom<ListProvidersSubcommand> for NativeOperation {
+impl TryFrom<&ListProvidersSubcommand> for NativeOperation {
     type Error = ParsecToolError;
 
-    fn try_from(_list_providers_subcommand: ListProvidersSubcommand) -> Result<Self, Self::Error> {
+    fn try_from(_list_providers_subcommand: &ListProvidersSubcommand) -> Result<Self, Self::Error> {
         // Trivially converted to a `NativeOperation`.
         Ok(NativeOperation::ListProviders(list_providers::Operation {}))
     }
 }
 
-impl ParsecToolSubcommand for ListProvidersSubcommand {
+impl ParsecToolSubcommand<'_> for ListProvidersSubcommand {
     /// Lists the available providers supported by the Parsec service.
     fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
-            NativeOperation::try_from(*self)?,
+            NativeOperation::try_from(self)?,
             ProviderID::Core,
             &matches.authentication_data(),
         )?;

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -24,13 +24,18 @@ use structopt::StructOpt;
 /// - They are convertible to a `NativeOperation` -- i.e. they can all be converted to messages to
 ///   the Parsec service. The conversion is fallible.
 /// - They implement `run`, which executes the subcommand.
-pub trait ParsecToolSubcommand: StructOpt + TryInto<NativeOperation> {
+pub trait ParsecToolSubcommand<'a>
+where
+    Self: 'a,
+    Self: StructOpt,
+    &'a Self: TryInto<NativeOperation>,
+{
     /// Run the subcommand.
     fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError>;
 }
 
 /// Command-line interface to Parsec operations.
-#[derive(Copy, Clone, Debug, StructOpt)]
+#[derive(Debug, StructOpt)]
 pub enum Subcommand {
     /// Pings the Parsec service and prints the wire protocol version.
     Ping(PingSubcommand),

--- a/src/subcommands/ping.rs
+++ b/src/subcommands/ping.rs
@@ -14,27 +14,27 @@ use std::convert::TryFrom;
 use structopt::StructOpt;
 
 /// Pings the Parsec service.
-#[derive(Copy, Clone, Debug, StructOpt)]
+#[derive(Debug, StructOpt)]
 #[structopt(name = "ping")]
 pub struct PingSubcommand {}
 
-impl TryFrom<PingSubcommand> for NativeOperation {
+impl TryFrom<&PingSubcommand> for NativeOperation {
     type Error = ParsecToolError;
 
-    fn try_from(_ping_subcommand: PingSubcommand) -> Result<NativeOperation, Self::Error> {
+    fn try_from(_ping_subcommand: &PingSubcommand) -> Result<NativeOperation, Self::Error> {
         // Trivially converted to a `NativeOperation`.
         Ok(NativeOperation::Ping(ping::Operation {}))
     }
 }
 
-impl ParsecToolSubcommand for PingSubcommand {
+impl ParsecToolSubcommand<'_> for PingSubcommand {
     /// Pings the Parsec service and prints the wire protocol version.
     fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
         info!("Pinging Parsec service...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
-            NativeOperation::try_from(*self)?,
+            NativeOperation::try_from(self)?,
             ProviderID::Core,
             &matches.authentication_data(),
         )?;


### PR DESCRIPTION
This commit changes the trait so that the required `TryInto`
implementation for `ParsecToolSubcommand` traits accepts a reference.
This avoids making unnecessary copies and ultimately permits greater
flexibility for the CLI.

Signed-off-by: Joe Ellis <joe.ellis@arm.com>