### PR TITLE
Add the generate and destroy key operations

### DIFF
--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -7,17 +7,19 @@ pub mod common;
 pub mod list_opcodes;
 pub mod list_providers;
 pub mod ping;
+pub mod psa_destroy_key;
 pub mod psa_export_key;
 pub mod psa_export_public_key;
+pub mod psa_generate_key;
 pub mod psa_generate_random;
 
 use crate::cli::ParsecToolApp;
 use crate::error::ParsecToolError;
 use crate::subcommands::{
     list_opcodes::ListOpcodesSubcommand, list_providers::ListProvidersSubcommand,
-    ping::PingSubcommand, psa_export_key::PsaExportKeySubcommand,
-    psa_export_public_key::PsaExportPublicKeySubcommand,
-    psa_generate_random::PsaGenerateRandomSubcommand,
+    ping::PingSubcommand, psa_destroy_key::PsaDestroyKeySubcommand,
+    psa_export_key::PsaExportKeySubcommand, psa_export_public_key::PsaExportPublicKeySubcommand,
+    psa_generate_key::PsaGenerateKeySubcommand, psa_generate_random::PsaGenerateRandomSubcommand,
 };
 use anyhow::Result;
 use parsec_client::core::interface::operations::NativeOperation;
@@ -59,6 +61,12 @@ pub enum Subcommand {
 
     /// Lists the supported opcodes for a given provider.
     PsaExportKey(PsaExportKeySubcommand),
+
+    /// Generates a key.
+    PsaGenerateKey(PsaGenerateKeySubcommand),
+
+    /// Destroys a key.
+    PsaDestroyKey(PsaDestroyKeySubcommand),
 }
 
 impl Subcommand {
@@ -71,6 +79,8 @@ impl Subcommand {
             Subcommand::PsaGenerateRandom(cmd) => cmd.run(matches),
             Subcommand::PsaExportPublicKey(cmd) => cmd.run(matches),
             Subcommand::PsaExportKey(cmd) => cmd.run(matches),
+            Subcommand::PsaGenerateKey(cmd) => cmd.run(matches),
+            Subcommand::PsaDestroyKey(cmd) => cmd.run(matches),
         }
     }
 }

--- a/src/subcommands/psa_destroy_key.rs
+++ b/src/subcommands/psa_destroy_key.rs
@@ -1,0 +1,62 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Destroys a key.
+
+pub use crate::cli::ParsecToolApp;
+use crate::error::ParsecToolError;
+use crate::subcommands::common::ProviderOpts;
+use crate::subcommands::ParsecToolSubcommand;
+use parsec_client::core::interface::operations::psa_destroy_key;
+use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
+use parsec_client::core::interface::requests::ProviderID;
+use parsec_client::core::operation_client::OperationClient;
+use std::convert::TryFrom;
+use structopt::StructOpt;
+
+/// Destroys a key.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "destroy-key")]
+pub struct PsaDestroyKeySubcommand {
+    #[structopt(short = "k", long = "key-name")]
+    key_name: String,
+
+    #[structopt(flatten)]
+    provider_opts: ProviderOpts,
+}
+
+impl TryFrom<&PsaDestroyKeySubcommand> for NativeOperation {
+    type Error = ParsecToolError;
+
+    fn try_from(
+        psa_destroy_key_subcommand: &PsaDestroyKeySubcommand,
+    ) -> Result<NativeOperation, Self::Error> {
+        Ok(NativeOperation::PsaDestroyKey(psa_destroy_key::Operation {
+            key_name: psa_destroy_key_subcommand.key_name.clone(),
+        }))
+    }
+}
+
+impl ParsecToolSubcommand<'_> for PsaDestroyKeySubcommand {
+    /// Destroys a key.
+    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+        info!("Destroying a key...");
+
+        let client = OperationClient::new();
+        let native_result = client.process_operation(
+            NativeOperation::try_from(self)?,
+            ProviderID::try_from(self.provider_opts.provider)?,
+            &matches.authentication_data(),
+        )?;
+
+        match native_result {
+            NativeResult::PsaDestroyKey(_) => (),
+            _ => {
+                return Err(ParsecToolError::UnexpectedNativeResult(native_result));
+            }
+        };
+
+        success!("Key \"{}\" destroyed.", self.key_name);
+        Ok(())
+    }
+}

--- a/src/subcommands/psa_generate_key.rs
+++ b/src/subcommands/psa_generate_key.rs
@@ -1,0 +1,92 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generates a key.
+//!
+//! Currently a lot of the parameters of the key generation are hardcoded because it is not clear
+//! on how it will be possible in the future to generate a key from the command line. This is
+//! currently useful for playing with the tool, and demonstrating the use of Parsec.
+//!
+//! This will generate a 2048 bits RSA key pair for signing.
+
+pub use crate::cli::ParsecToolApp;
+use crate::error::ParsecToolError;
+use crate::subcommands::common::ProviderOpts;
+use crate::subcommands::ParsecToolSubcommand;
+use parsec_client::core::interface::operations::psa_algorithm::{AsymmetricSignature, Hash};
+use parsec_client::core::interface::operations::psa_generate_key;
+use parsec_client::core::interface::operations::psa_key_attributes::{
+    Attributes, Lifetime, Policy, Type, UsageFlags,
+};
+use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
+use parsec_client::core::interface::requests::ProviderID;
+use parsec_client::core::operation_client::OperationClient;
+use std::convert::TryFrom;
+use structopt::StructOpt;
+
+/// Generates a key.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "generate-key")]
+pub struct PsaGenerateKeySubcommand {
+    #[structopt(short = "k", long = "key-name")]
+    key_name: String,
+
+    #[structopt(flatten)]
+    provider_opts: ProviderOpts,
+}
+
+impl TryFrom<&PsaGenerateKeySubcommand> for NativeOperation {
+    type Error = ParsecToolError;
+
+    fn try_from(
+        psa_generate_key_subcommand: &PsaGenerateKeySubcommand,
+    ) -> Result<NativeOperation, Self::Error> {
+        //TODO: All of the parameters are currently hardcoded to make it easier to use on the
+        //command line for testing/demos. In the future, we want to have more options and keep a
+        //relative simplicity.
+        Ok(NativeOperation::PsaGenerateKey(
+            psa_generate_key::Operation {
+                key_name: psa_generate_key_subcommand.key_name.clone(),
+                attributes: Attributes {
+                    lifetime: Lifetime::Persistent,
+                    key_type: Type::RsaKeyPair,
+                    bits: 2048,
+                    policy: Policy {
+                        usage_flags: UsageFlags {
+                            sign_hash: true,
+                            ..Default::default()
+                        },
+                        permitted_algorithms: AsymmetricSignature::RsaPkcs1v15Sign {
+                            hash_alg: Hash::Sha256.into(),
+                        }
+                        .into(),
+                    },
+                },
+            },
+        ))
+    }
+}
+
+impl ParsecToolSubcommand<'_> for PsaGenerateKeySubcommand {
+    /// Exports a key.
+    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+        info!("Generating key...");
+
+        let client = OperationClient::new();
+        let native_result = client.process_operation(
+            NativeOperation::try_from(self)?,
+            ProviderID::try_from(self.provider_opts.provider)?,
+            &matches.authentication_data(),
+        )?;
+
+        match native_result {
+            NativeResult::PsaGenerateKey(_) => (),
+            _ => {
+                return Err(ParsecToolError::UnexpectedNativeResult(native_result));
+            }
+        };
+
+        success!("Key \"{}\" generated.", self.key_name);
+        Ok(())
+    }
+}


### PR DESCRIPTION
The Generate key one currently hardcodes the key to 2048 bits RSA to make it easier to use on the CLI.

I tested it and it works well 😄 

```
[hugdev01@machine parsec-tool]$ ./target/debug/parsec-tool -a tata psa-generate-key -k toto -p 1
[INFO] Generating key...
[hugdev01@machine parsec-tool]$ ./target/debug/parsec-tool -a tata psa-export-public-key -k toto -p 1
[INFO] Exporting public key...
[SUCCESS] Key:
30 82 01 0A 02 82 01 01 00 CF 35 30 8A C6 11 B0 F3 C8 5C 4C 80 46 D7 EE BD 14 20 10 C6 E4 07 0D 83 63 79 B9 36 1C 0D 8D 1C E2 CB 0F 0E CC 33 F8 F0 B2 28 AC 3F B8 A2 B9 1E BC 98 6B 74 95 D6 34 34 74 90 73 72 80 C8 0C 3C CF BF 8A A7 5B C2 30 68 B3 DE 06 75 01 27 30 AE CC 3C AC 7F B8 B5 01 0E 2D 61 32 BD 18 D1 FC B2 C4 D3 12 61 72 B0 C0 19 19 C7 BF 1E BE C2 97 C8 FA 70 9F 7E 52 90 07 8D B9 10 6E 22 F5 50 0D 2D 62 D6 60 89 D6 E7 71 02 DD 6D 41 BF 4D 58 6C 84 86 D7 B9 FA 2F 26 FD 07 30 79 C3 27 25 E0 63 99 BF 01 79 7D 05 F7 AE 17 40 DD DD B5 F4 1E 12 65 09 9E 97 50 54 50 B7 6C 4B AB 0A BC EE 72 AC 79 F6 30 5A 55 EA 86 EE 29 8C EA BC 13 18 EC D5 D9 BE 7B E1 C9 AC 45 FD 85 39 42 72 0C AD 95 90 E7 F4 AF 71 50 1F 49 63 E9 78 4A 22 43 FE A8 A5 A3 60 E8 74 61 83 93 69 8D A2 44 62 58 3E CA 72 DB 02 03 01 00 01
[hugdev01@machine parsec-tool]$ ./target/debug/parsec-tool -a tata psa-destroy-key -k toto -p 1
[INFO] Destroying a key...
[hugdev01@machine parsec-tool]$ ./target/debug/parsec-tool -a tata psa-export-public-key -k toto -p 1
[INFO] Exporting public key...
[ERR] Executing subcommand failed.

Caused by:
    asking for an item that doesn't exist
```

Will rebase on top of the other PR once merged.