### PR TITLE
Make use of client bootstrapping functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,8 +450,7 @@ checksum = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
 [[package]]
 name = "parsec-client"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778d18e6c3292ed673a9bf9f4b3f86b6bc22b32d24047d67ec6df430959b9de5"
+source = "git+https://github.com/parallaxsecond/parsec-client-rust?rev=3f7dfc7bd06bea7cb3aa38cdcb270af7b8899f89#3f7dfc7bd06bea7cb3aa38cdcb270af7b8899f89"
 dependencies = [
  "derivative",
  "log",
@@ -464,8 +463,7 @@ dependencies = [
 [[package]]
 name = "parsec-interface"
 version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275562850cb6ba82ce17d840cef8279f9649441bc596262e7dd92983e77257b6"
+source = "git+https://github.com/parallaxsecond/parsec-interface-rs.git?rev=ce3590dc0cb7f345f328fec0dc22073da1b4699c#ce3590dc0cb7f345f328fec0dc22073da1b4699c"
 dependencies = [
  "bincode",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ansi_term = "0.12.1"
 anyhow = "1.0.32"
 atty = "0.2.14"
 clap = "3.0.0-beta.1"
-parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust.git", rev = "dbd449a9e736f9f972e5489fb2d67949b93484dc" }
+parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", rev = "3f7dfc7bd06bea7cb3aa38cdcb270af7b8899f89" }
 structopt = "0.3.17"
 thiserror = "1.0.20"
 

--- a/src/subcommands/common.rs
+++ b/src/subcommands/common.rs
@@ -3,6 +3,10 @@
 
 //! Common facilities and options for subcommands.
 
+use crate::error::ParsecToolError;
+use parsec_client::core::interface::requests::ProviderID;
+use parsec_client::BasicClient;
+use std::convert::TryFrom;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -13,6 +17,23 @@ pub struct ProviderOpts {
     /// The provider to list opcodes for.
     #[structopt(short = "p", long = "provider", default_value = "0")]
     pub provider: u8,
+}
+
+impl ProviderOpts {
+    /// Get the ProviderID selected by the user or the service default if
+    /// no provider was selected.
+    ///
+    /// The Core Provider cannot be used and will be overriden by the
+    /// service default.
+    pub fn provider(&self) -> Result<ProviderID, ParsecToolError> {
+        if self.provider != 0 {
+            Ok(ProviderID::try_from(self.provider)?)
+        } else {
+            let mut client = BasicClient::new_naked();
+            client.set_default_provider()?;
+            Ok(client.implicit_provider())
+        }
+    }
 }
 
 /// Options for specifying an output file.

--- a/src/subcommands/list_keys.rs
+++ b/src/subcommands/list_keys.rs
@@ -33,7 +33,7 @@ impl ParsecToolSubcommand<'_> for ListKeysSubcommand {
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             ProviderID::Core,
-            &matches.authentication_data(),
+            &matches.authentication_data()?,
         )?;
 
         if let NativeResult::ListKeys(result) = native_result {

--- a/src/subcommands/list_opcodes.rs
+++ b/src/subcommands/list_opcodes.rs
@@ -42,13 +42,13 @@ impl ParsecToolSubcommand<'_> for ListOpcodesSubcommand {
             // We still use the core provider beacuse listing opcodes is a core operation. Note the
             // distinction between the provider we're _using_ and the provider we're querying.
             ProviderID::Core,
-            &matches.authentication_data(),
+            &matches.authentication_data()?,
         )?;
 
         if let NativeResult::ListOpcodes(result) = native_result {
             info!(
                 "Available opcodes for provider {:?}:",
-                ProviderID::try_from(self.provider_opts.provider)?
+                self.provider_opts.provider()?
             );
             for provider_opcode in result.opcodes {
                 eprint_colored!(Blue, "*");

--- a/src/subcommands/list_providers.rs
+++ b/src/subcommands/list_providers.rs
@@ -34,7 +34,7 @@ impl ParsecToolSubcommand<'_> for ListProvidersSubcommand {
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             ProviderID::Core,
-            &matches.authentication_data(),
+            &matches.authentication_data()?,
         )?;
 
         if let NativeResult::ListProviders(result) = native_result {

--- a/src/subcommands/ping.rs
+++ b/src/subcommands/ping.rs
@@ -36,7 +36,7 @@ impl ParsecToolSubcommand<'_> for PingSubcommand {
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             ProviderID::Core,
-            &matches.authentication_data(),
+            &matches.authentication_data()?,
         )?;
 
         if let NativeResult::Ping(result) = native_result {

--- a/src/subcommands/psa_destroy_key.rs
+++ b/src/subcommands/psa_destroy_key.rs
@@ -9,7 +9,6 @@ use crate::subcommands::common::ProviderOpts;
 use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::psa_destroy_key;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
-use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
@@ -45,8 +44,8 @@ impl ParsecToolSubcommand<'_> for PsaDestroyKeySubcommand {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
-            ProviderID::try_from(self.provider_opts.provider)?,
-            &matches.authentication_data(),
+            self.provider_opts.provider()?,
+            &matches.authentication_data()?,
         )?;
 
         match native_result {

--- a/src/subcommands/psa_export_key.rs
+++ b/src/subcommands/psa_export_key.rs
@@ -9,7 +9,6 @@ use crate::subcommands::common::{OutputFileOpts, ProviderOpts};
 use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::psa_export_key;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
-use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::interface::secrecy::ExposeSecret;
 use parsec_client::core::operation_client::OperationClient;
 use std::convert::TryFrom;
@@ -52,8 +51,8 @@ impl ParsecToolSubcommand<'_> for PsaExportKeySubcommand {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
-            ProviderID::try_from(self.provider_opts.provider)?,
-            &matches.authentication_data(),
+            self.provider_opts.provider()?,
+            &matches.authentication_data()?,
         )?;
 
         let result = match native_result {

--- a/src/subcommands/psa_export_public_key.rs
+++ b/src/subcommands/psa_export_public_key.rs
@@ -9,7 +9,6 @@ use crate::subcommands::common::{OutputFileOpts, ProviderOpts};
 use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::psa_export_public_key;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
-use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
 use std::convert::TryFrom;
 use std::fs::File;
@@ -53,8 +52,8 @@ impl ParsecToolSubcommand<'_> for PsaExportPublicKeySubcommand {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
-            ProviderID::try_from(self.provider_opts.provider)?,
-            &matches.authentication_data(),
+            self.provider_opts.provider()?,
+            &matches.authentication_data()?,
         )?;
 
         let result = match native_result {

--- a/src/subcommands/psa_generate_key.rs
+++ b/src/subcommands/psa_generate_key.rs
@@ -19,7 +19,6 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
     Attributes, Lifetime, Policy, Type, UsageFlags,
 };
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
-use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
@@ -75,8 +74,8 @@ impl ParsecToolSubcommand<'_> for PsaGenerateKeySubcommand {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
-            ProviderID::try_from(self.provider_opts.provider)?,
-            &matches.authentication_data(),
+            self.provider_opts.provider()?,
+            &matches.authentication_data()?,
         )?;
 
         match native_result {

--- a/src/subcommands/psa_generate_random.rs
+++ b/src/subcommands/psa_generate_random.rs
@@ -9,7 +9,6 @@ use crate::subcommands::common::{OutputFileOpts, ProviderOpts};
 use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::psa_generate_random;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
-use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
 use std::convert::TryFrom;
 use std::fs::File;
@@ -52,8 +51,8 @@ impl ParsecToolSubcommand<'_> for PsaGenerateRandomSubcommand {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
-            ProviderID::try_from(self.provider_opts.provider)?,
-            &matches.authentication_data(),
+            self.provider_opts.provider()?,
+            &matches.authentication_data()?,
         )?;
 
         let result = match native_result {


### PR DESCRIPTION
This commit changes the way the provider and authentication is chosen
for each command by using the bootstrapping functionality implemented in
the client.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>