### PR TITLE
Add BasicClient to ParsecToolApp

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,10 +4,7 @@
 //! Base CLI implementation.
 
 use crate::common::{PROJECT_AUTHOR, PROJECT_DESC, PROJECT_NAME, PROJECT_VERSION};
-use crate::error::ParsecToolError;
 use crate::subcommands::Subcommand;
-use parsec_client::auth::Authentication;
-use parsec_client::BasicClient;
 use structopt::StructOpt;
 
 /// Struct representing the command-line interface of parsec-tool.
@@ -26,15 +23,4 @@ pub struct ParsecToolApp {
     /// The subcommand -- e.g., ping.
     #[structopt(subcommand)]
     pub subcommand: Subcommand,
-}
-
-impl ParsecToolApp {
-    /// Given an optional app name, generate the corresponding Authentication instance. This method
-    /// makes use of the authentication bootstrapping mechanism in `BasicClient` to obtain the
-    /// appropriate data for the tool.
-    pub fn authentication_data(&self) -> Result<Authentication, ParsecToolError> {
-        let mut client = BasicClient::new_naked();
-        client.set_default_auth(self.app_name.clone())?;
-        Ok(client.auth_data())
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,20 @@
 
 //! parsec-tool: a tool for interfacing with the Parsec service from the command-line.
 
-use parsec_tool::err;
-
+use parsec_client::BasicClient;
 use parsec_tool::cli;
+use parsec_tool::err;
 use structopt::StructOpt;
 
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
     let matches = cli::ParsecToolApp::from_args();
-    matches.subcommand.run(&matches).map_err(|e| {
+    let client = BasicClient::new(matches.app_name.clone()).map_err(|e| {
+        err!("{:?}", e);
+        std::io::Error::new(std::io::ErrorKind::Other, "Failed to spin up basic client.")
+    })?;
+    matches.subcommand.run(&matches, client).map_err(|e| {
         err!("{:?}", e);
         std::io::Error::new(std::io::ErrorKind::Other, "Executing subcommand failed.")
     })

--- a/src/subcommands/create_ecc_key.rs
+++ b/src/subcommands/create_ecc_key.rs
@@ -20,6 +20,7 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
 };
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -67,14 +68,18 @@ impl TryFrom<&CreateEccKey> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for CreateEccKey {
     /// Exports a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Generating key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {

--- a/src/subcommands/create_rsa_key.rs
+++ b/src/subcommands/create_rsa_key.rs
@@ -20,6 +20,7 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
 };
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -67,14 +68,18 @@ impl TryFrom<&CreateRsaKey> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for CreateRsaKey {
     /// Exports a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Generating key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {

--- a/src/subcommands/decrypt.rs
+++ b/src/subcommands/decrypt.rs
@@ -20,6 +20,7 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
 };
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -65,14 +66,18 @@ impl TryFrom<&Decrypt> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for Decrypt {
     /// Exports a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Generating key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {

--- a/src/subcommands/delete_client.rs
+++ b/src/subcommands/delete_client.rs
@@ -10,6 +10,7 @@ use parsec_client::core::interface::operations::{delete_client, NativeOperation,
 
 use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -32,12 +33,16 @@ impl TryFrom<&DeleteClient> for NativeOperation {
 }
 
 impl ParsecToolSubcommand<'_> for DeleteClient {
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             ProviderID::Core,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {

--- a/src/subcommands/delete_key.rs
+++ b/src/subcommands/delete_key.rs
@@ -10,6 +10,7 @@ use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::psa_destroy_key;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -35,14 +36,18 @@ impl TryFrom<&DeleteKey> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for DeleteKey {
     /// Destroys a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Destroying a key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {

--- a/src/subcommands/encrypt.rs
+++ b/src/subcommands/encrypt.rs
@@ -20,6 +20,7 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
 };
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -65,14 +66,18 @@ impl TryFrom<&Encrypt> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for Encrypt {
     /// Exports a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Generating key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {

--- a/src/subcommands/export_key.rs
+++ b/src/subcommands/export_key.rs
@@ -11,6 +11,7 @@ use parsec_client::core::interface::operations::psa_export_key;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::interface::secrecy::ExposeSecret;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::Write;
@@ -42,14 +43,18 @@ impl TryFrom<&ExportKey> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for ExportKey {
     /// Exports a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Exporting key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         let result = match native_result {

--- a/src/subcommands/export_public_key.rs
+++ b/src/subcommands/export_public_key.rs
@@ -10,6 +10,7 @@ use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::psa_export_public_key;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::Write;
@@ -45,14 +46,18 @@ impl TryFrom<&ExportPublicKey> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for ExportPublicKey {
     /// Exports a public key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Exporting public key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         let result = match native_result {

--- a/src/subcommands/generate_random.rs
+++ b/src/subcommands/generate_random.rs
@@ -10,6 +10,7 @@ use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::psa_generate_random;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::Write;
@@ -44,14 +45,18 @@ impl TryFrom<&GenerateRandom> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for GenerateRandom {
     /// Generates a sequence of random bytes.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Generating {} random bytes...", self.nbytes);
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         let result = match native_result {

--- a/src/subcommands/list_authenticators.rs
+++ b/src/subcommands/list_authenticators.rs
@@ -11,6 +11,7 @@ use parsec_client::core::interface::operations::list_authenticators;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -31,7 +32,11 @@ impl TryFrom<&ListAuthenticators> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for ListAuthenticators {
     /// Lists the available authenticators supported by the Parsec service.
-    fn run(&self, _matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        _basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,

--- a/src/subcommands/list_clients.rs
+++ b/src/subcommands/list_clients.rs
@@ -10,6 +10,7 @@ use parsec_client::core::interface::operations::{list_clients, NativeOperation, 
 
 use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -27,12 +28,16 @@ impl TryFrom<&ListClients> for NativeOperation {
 }
 
 impl ParsecToolSubcommand<'_> for ListClients {
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             ProviderID::Core,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         if let NativeResult::ListClients(result) = native_result {

--- a/src/subcommands/list_keys.rs
+++ b/src/subcommands/list_keys.rs
@@ -9,6 +9,7 @@ use crate::subcommands::ParsecToolSubcommand;
 use parsec_client::core::interface::operations::{list_keys, NativeOperation, NativeResult};
 use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -27,12 +28,16 @@ impl TryFrom<&ListKeys> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for ListKeys {
     /// Lists the available providers supported by the Parsec service.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             ProviderID::Core,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         if let NativeResult::ListKeys(result) = native_result {

--- a/src/subcommands/list_opcodes.rs
+++ b/src/subcommands/list_opcodes.rs
@@ -12,6 +12,7 @@ use parsec_client::core::interface::operations::list_opcodes;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -35,7 +36,11 @@ impl TryFrom<&ListOpcodes> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for ListOpcodes {
     /// Lists the supported opcodes for a given provider.
-    fn run(&self, _matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        _basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,

--- a/src/subcommands/list_providers.rs
+++ b/src/subcommands/list_providers.rs
@@ -11,6 +11,7 @@ use parsec_client::core::interface::operations::list_providers;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -29,7 +30,11 @@ impl TryFrom<&ListProviders> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for ListProviders {
     /// Lists the available providers supported by the Parsec service.
-    fn run(&self, _matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        _basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -33,6 +33,7 @@ use crate::subcommands::{
     verify::Verify,
 };
 use parsec_client::core::interface::operations::NativeOperation;
+use parsec_client::BasicClient;
 use std::convert::TryInto;
 use structopt::StructOpt;
 
@@ -48,7 +49,7 @@ where
     &'a Self: TryInto<NativeOperation>,
 {
     /// Run the subcommand.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError>;
+    fn run(&self, matches: &ParsecToolApp, client: BasicClient) -> Result<(), ParsecToolError>;
 }
 
 /// Command-line interface to Parsec operations.
@@ -108,25 +109,25 @@ pub enum Subcommand {
 
 impl Subcommand {
     /// Runs the subcommand.
-    pub fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    pub fn run(&self, matches: &ParsecToolApp, client: BasicClient) -> Result<(), ParsecToolError> {
         match &self {
-            Subcommand::Ping(cmd) => cmd.run(matches),
-            Subcommand::ListProviders(cmd) => cmd.run(matches),
-            Subcommand::ListAuthenticators(cmd) => cmd.run(matches),
-            Subcommand::ListKeys(cmd) => cmd.run(matches),
-            Subcommand::ListClients(cmd) => cmd.run(matches),
-            Subcommand::DeleteClient(cmd) => cmd.run(matches),
-            Subcommand::ListOpcodes(cmd) => cmd.run(matches),
-            Subcommand::GenerateRandom(cmd) => cmd.run(matches),
-            Subcommand::ExportPublicKey(cmd) => cmd.run(matches),
-            Subcommand::ExportKey(cmd) => cmd.run(matches),
-            Subcommand::CreateRsaKey(cmd) => cmd.run(matches),
-            Subcommand::CreateEccKey(cmd) => cmd.run(matches),
-            Subcommand::Sign(cmd) => cmd.run(matches),
-            Subcommand::Verify(cmd) => cmd.run(matches),
-            Subcommand::Encrypt(cmd) => cmd.run(matches),
-            Subcommand::Decrypt(cmd) => cmd.run(matches),
-            Subcommand::DeleteKey(cmd) => cmd.run(matches),
+            Subcommand::Ping(cmd) => cmd.run(matches, client),
+            Subcommand::ListProviders(cmd) => cmd.run(matches, client),
+            Subcommand::ListAuthenticators(cmd) => cmd.run(matches, client),
+            Subcommand::ListKeys(cmd) => cmd.run(matches, client),
+            Subcommand::ListClients(cmd) => cmd.run(matches, client),
+            Subcommand::DeleteClient(cmd) => cmd.run(matches, client),
+            Subcommand::ListOpcodes(cmd) => cmd.run(matches, client),
+            Subcommand::GenerateRandom(cmd) => cmd.run(matches, client),
+            Subcommand::ExportPublicKey(cmd) => cmd.run(matches, client),
+            Subcommand::ExportKey(cmd) => cmd.run(matches, client),
+            Subcommand::CreateRsaKey(cmd) => cmd.run(matches, client),
+            Subcommand::CreateEccKey(cmd) => cmd.run(matches, client),
+            Subcommand::Sign(cmd) => cmd.run(matches, client),
+            Subcommand::Verify(cmd) => cmd.run(matches, client),
+            Subcommand::Encrypt(cmd) => cmd.run(matches, client),
+            Subcommand::Decrypt(cmd) => cmd.run(matches, client),
+            Subcommand::DeleteKey(cmd) => cmd.run(matches, client),
         }
     }
 }

--- a/src/subcommands/ping.rs
+++ b/src/subcommands/ping.rs
@@ -11,6 +11,7 @@ use parsec_client::core::interface::operations::ping;
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::interface::requests::ProviderID;
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -29,7 +30,11 @@ impl TryFrom<&Ping> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for Ping {
     /// Pings the Parsec service and prints the wire protocol version.
-    fn run(&self, _matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        _basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Pinging Parsec service...");
 
         let client = OperationClient::new();

--- a/src/subcommands/sign.rs
+++ b/src/subcommands/sign.rs
@@ -20,6 +20,7 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
 };
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -65,14 +66,18 @@ impl TryFrom<&Sign> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for Sign {
     /// Exports a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Generating key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {

--- a/src/subcommands/verify.rs
+++ b/src/subcommands/verify.rs
@@ -20,6 +20,7 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
 };
 use parsec_client::core::interface::operations::{NativeOperation, NativeResult};
 use parsec_client::core::operation_client::OperationClient;
+use parsec_client::BasicClient;
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -65,14 +66,18 @@ impl TryFrom<&Verify> for NativeOperation {
 
 impl ParsecToolSubcommand<'_> for Verify {
     /// Exports a key.
-    fn run(&self, matches: &ParsecToolApp) -> Result<(), ParsecToolError> {
+    fn run(
+        &self,
+        _matches: &ParsecToolApp,
+        basic_client: BasicClient,
+    ) -> Result<(), ParsecToolError> {
         info!("Generating key...");
 
         let client = OperationClient::new();
         let native_result = client.process_operation(
             NativeOperation::try_from(self)?,
             self.provider_opts.provider()?,
-            &matches.authentication_data()?,
+            &basic_client.auth_data(),
         )?;
 
         match native_result {


### PR DESCRIPTION
This commit adds an instance of BasicClient to the ParsecToolApp so that
all subcommands can simply use this one instead of spinning up their
own.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>