### PR TITLE
Format public key to PEM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,8 +422,20 @@ dependencies = [
  "clap 3.0.0-beta.2",
  "env_logger",
  "parsec-client",
+ "pem",
  "structopt",
  "thiserror",
+]
+
+[[package]]
+name = "pem"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c220d01f863d13d96ca82359d1e81e64a7c6bf0637bcde7b2349630addf0c6"
+dependencies = [
+ "base64",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", 
 structopt = "0.3.17"
 thiserror = "1.0.20"
 env_logger = "0.8.2"
+pem = "0.8.2"
 
 [lib]
 name = "parsec_tool"


### PR DESCRIPTION
This commit modifies the export public key operation to format the
output as PEM. Depending on the "output" flag, the result is either
printed to stdout or written to a file.

Close #28