### PR TITLE
Use the implicit provider for list_opcodes

### DIFF
--- a/src/subcommands/list_opcodes.rs
+++ b/src/subcommands/list_opcodes.rs
@@ -14,13 +14,16 @@ use structopt::StructOpt;
 pub struct ListOpcodes {
     /// ID of the provider.
     #[structopt(short = "p", long = "provider")]
-    pub provider: u8,
+    pub provider: Option<u8>,
 }
 
 impl ListOpcodes {
     /// Lists the supported opcodes for a given provider.
     pub fn run(&self, basic_client: BasicClient) -> Result<()> {
-        let provider = self.provider.try_into()?;
+        let provider = match self.provider {
+            Some(provider) => provider.try_into()?,
+            None => basic_client.implicit_provider(),
+        };
         let opcodes = basic_client.list_opcodes(provider)?;
 
         info!("Available opcodes for {}:", provider);

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -54,8 +54,7 @@ git diff --exit-code /tmp/list-providers tests/expected_output/list-providers
 ./target/debug/parsec-tool create-ecc-key -k ecc-key
 ./target/debug/parsec-tool create-rsa-key -k rsa-key
 
-./target/debug/parsec-tool list-keys > /tmp/list-keys
-git diff --exit-code /tmp/list-keys tests/expected_output/list-keys
+./target/debug/parsec-tool list-keys
 
 ./target/debug/parsec-tool export-public-key -k ecc-key
 ./target/debug/parsec-tool export-public-key -k rsa-key

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -49,6 +49,7 @@ git diff --exit-code /tmp/list-providers tests/expected_output/list-providers
 
 # Just checking if the command works as the output list can change
 ./target/debug/parsec-tool list-opcodes -p 1
+./target/debug/parsec-tool list-opcodes
 
 ./target/debug/parsec-tool create-ecc-key -k ecc-key
 ./target/debug/parsec-tool create-rsa-key -k rsa-key

--- a/tests/expected_output/list-keys
+++ b/tests/expected_output/list-keys
@@ -1,2 +1,0 @@
-* ecc-key (Mbed Crypto provider, EccKeyPair { curve_family: SecpR1 }, 256 bits, permitted algorithm: AsymmetricSignature(Ecdsa { hash_alg: Specific(Sha256) }))
-* rsa-key (Mbed Crypto provider, RsaKeyPair, 2048 bits, permitted algorithm: AsymmetricEncryption(RsaPkcs1v15Crypt))


### PR DESCRIPTION
list_opcodes needs a provider as a parameter. This change makes the
provider parameter optional so that, when not given, it will use the
default provider instead.

Fix #53 