### PR TITLE
Early support for certificate request generation in parsec-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "yasna",
+ "yasna 0.3.2",
  "zeroize",
 ]
 
@@ -596,7 +596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
 dependencies = [
  "base64 0.12.3",
- "pem",
+ "pem 0.8.3",
  "ring",
  "serde",
  "serde_json",
@@ -925,10 +925,11 @@ dependencies = [
  "log",
  "oid",
  "parsec-client",
- "pem",
+ "pem 0.8.3",
  "picky-asn1",
  "picky-asn1-der",
  "picky-asn1-x509",
+ "rcgen",
  "serde",
  "sha2",
  "structopt",
@@ -946,6 +947,17 @@ name = "pem"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "pem"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06673860db84d02a63942fa69cd9543f2624a5df3aea7f33173048fa7ad5cf1a"
 dependencies = [
  "base64 0.13.0",
  "once_cell",
@@ -1132,6 +1144,18 @@ name = "radium"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
+name = "rcgen"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
+dependencies = [
+ "chrono",
+ "pem 1.0.1",
+ "ring",
+ "yasna 0.4.0",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1735,6 +1759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 dependencies = [
  "num-bigint 0.2.6",
+]
+
+[[package]]
+name = "yasna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ picky-asn1-x509 = "0.6.1"
 serde = "1.0.123"
 sha2 = "0.9.5"
 log = "0.4.14"
+rcgen = { version = "0.8.14", features = ["pem"] }
 
 [lib]
 name = "parsec_tool"

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,10 @@ pub enum Error {
     /// Error emanating from the base64 crate.
     #[error(transparent)]
     Base64Decode(#[from] base64::DecodeError),
+
+    /// Error emanating from the rcgen create (can occur when creating certificates or CSRs)
+    #[error(transparent)]
+    RcgenError(#[from] rcgen::RcgenError),
 }
 
 /// Errors originating in the parsec-tool.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,4 @@ pub mod cli;
 pub mod common;
 pub mod error;
 pub mod subcommands;
+pub mod util;

--- a/src/subcommands/create_csr.rs
+++ b/src/subcommands/create_csr.rs
@@ -1,0 +1,262 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Creates a Certificate Signing Request (CSR) from a keypair.
+
+use crate::error::{Error, Result, ToolErrorKind};
+use crate::util::sign_message_with_policy;
+use log::error;
+use parsec_client::core::interface::operations::psa_algorithm::{
+    Algorithm, AsymmetricSignature, Hash, SignHash,
+};
+use parsec_client::core::interface::operations::psa_key_attributes::{EccFamily, Type};
+use parsec_client::BasicClient;
+use rcgen::{
+    Certificate, CertificateParams, DistinguishedName, DnType, KeyPair, RcgenError, RemoteKeyPair,
+    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_RSA_SHA256,
+    PKCS_RSA_SHA384, PKCS_RSA_SHA512,
+};
+use structopt::StructOpt;
+
+/// Creates an X509 Certificate Signing Request (CSR) from a keypair, using the signing algorithm
+/// that is associated with the key.
+///
+/// The CSR is written to the standard output in PEM format by default.
+#[derive(Debug, StructOpt)]
+pub struct CreateCsr {
+    /// The name of the key to use for signing. This must be an existing key that is accessible
+    /// to the user, and it must be a signing key (either an RSA key or an elliptic curve key).
+    ///
+    /// Elliptic curve keys must use the NIST P256 or P384 curves.
+    #[structopt(short = "k", long = "key-name")]
+    key_name: String,
+
+    /// The common name to be used within the Distinguished Name (DN) specification of
+    /// the CSR.
+    #[structopt(long = "cn")]
+    common_name: Option<String>,
+
+    /// The locality name to be used within the Distinguished Name (DN) specification of
+    /// the CSR.
+    #[structopt(long = "l")]
+    locality: Option<String>,
+
+    /// The organization name to be used within the Distinguished Name (DN) specification of
+    /// the CSR.
+    #[structopt(long = "o")]
+    organization: Option<String>,
+
+    /// The organizational unit name to be used within the Distinguished Name (DN) specification
+    /// of the CSR.
+    #[structopt(long = "ou")]
+    organizational_unit: Option<String>,
+
+    /// The state name to be used within the Distinguished Name (DN) specification of the CSR.
+    #[structopt(long = "st")]
+    state: Option<String>,
+
+    /// The country name to be used within the Distinguished Name (DN) specification of the CSR.
+    #[structopt(long = "c")]
+    country: Option<String>,
+
+    /// A Subject Alternative Name (SAN) for the domain of the CSR.
+    #[structopt(long = "san")]
+    subject_alternative_name: Option<Vec<String>>,
+}
+
+/// Short-lived structure to encapsulate the key name and the client, so that we can implement the
+/// RemoteKeyPair trait for rcgen.
+struct ParsecRemoteKeyPair {
+    key_name: String,
+    public_key_der: Vec<u8>,
+    parsec_client: BasicClient,
+    rcgen_algorithm: &'static SignatureAlgorithm,
+}
+
+impl CreateCsr {
+    /// Creates a Certificate Signing Request (CSR) from a keypair.
+    pub fn run(&self, basic_client: BasicClient) -> Result<()> {
+        let public_key = basic_client.psa_export_public_key(&self.key_name)?;
+
+        let rcgen_algorithm = self.get_rcgen_algorithm(&basic_client)?;
+
+        let parsec_key_pair = ParsecRemoteKeyPair {
+            key_name: self.key_name.clone(),
+            public_key_der: public_key.clone(),
+            // "Move" the client into the struct here.
+            parsec_client: basic_client,
+            rcgen_algorithm: rcgen_algorithm,
+        };
+
+        let remote_key_pair = KeyPair::from_remote(Box::new(parsec_key_pair))?;
+
+        let subject_alt_names = match &self.subject_alternative_name {
+            Some(san) => san.to_owned(),
+            None => Vec::new(),
+        };
+
+        let mut dn = DistinguishedName::new();
+
+        if let Some(common_name) = &self.common_name {
+            dn.push(DnType::CommonName, common_name.clone());
+        }
+
+        if let Some(organizational_unit) = &self.organizational_unit {
+            // NOTE: X509 permits multiple OUs, but the RCGEN crate only preserves one entry, so for now the
+            // parsec-tool also only accepts one entry on the command-line. If this changes in the future, it
+            // will be possible to evolve the command-line parser to accept multiple values without it being
+            // a breaking change.
+            dn.push(DnType::OrganizationalUnitName, organizational_unit.clone());
+        }
+
+        if let Some(organization) = &self.organization {
+            dn.push(DnType::OrganizationName, organization.clone());
+        }
+
+        if let Some(locality) = &self.locality {
+            dn.push(DnType::LocalityName, locality.clone());
+        }
+
+        if let Some(state) = &self.state {
+            dn.push(DnType::StateOrProvinceName, state.clone());
+        }
+
+        if let Some(country) = &self.country {
+            dn.push(DnType::CountryName, country.clone());
+        }
+
+        let mut params = CertificateParams::new(subject_alt_names);
+        params.alg = rcgen_algorithm;
+        params.key_pair = Some(remote_key_pair);
+        params.distinguished_name = dn;
+
+        let cert = Certificate::from_params(params)?;
+
+        let pem_string = cert.serialize_request_pem()?;
+
+        println!("{}", pem_string);
+
+        Ok(())
+    }
+
+    // Inspect the attributes of the signing key and map them down to one of rcgen's supported hash-and-sign
+    // schemes (throwing an error if there isn't a suitable mapping).
+    //
+    // There's rather a lot of complexity here, because we need to map down lots of nested PSA properties onto a small number
+    // of hash-and-sign schemes that RCGEN supports.
+    fn get_rcgen_algorithm(
+        &self,
+        basic_client: &BasicClient,
+    ) -> Result<&'static SignatureAlgorithm> {
+        let attributes = basic_client.key_attributes(&self.key_name)?;
+
+        if let Algorithm::AsymmetricSignature(alg) = attributes.policy.permitted_algorithms {
+            match alg {
+                AsymmetricSignature::RsaPkcs1v15Sign { hash_alg } => match hash_alg {
+                    SignHash::Specific(Hash::Sha256) => Ok(&PKCS_RSA_SHA256),
+                    SignHash::Specific(Hash::Sha384) => Ok(&PKCS_RSA_SHA384),
+                    SignHash::Specific(Hash::Sha512) => Ok(&PKCS_RSA_SHA512),
+                    SignHash::Any => Ok(&PKCS_RSA_SHA256), // Default hash algorithm for the tool.
+                    _ => {
+                        // The algorithm is specific, but not one that RCGEN can use, so fail the operation.
+                        error!("Signing key requires use of hashing algorithm ({:?}), which is not supported for certificate requests.", alg);
+                        Err(ToolErrorKind::NotSupported.into())
+                    }
+                },
+                AsymmetricSignature::RsaPkcs1v15SignRaw => {
+                    // Key policy specifies raw RSA signatures. RCGEN will always hash-and-sign, so fail.
+                    error!("Signing key specifies raw signing only, which is not supported for certificate requests.");
+                    Err(ToolErrorKind::NotSupported.into())
+                }
+                AsymmetricSignature::RsaPss { .. } => {
+                    error!("Signing key specifies RSA PSS scheme, which is not supported for certificate requests.");
+                    Err(ToolErrorKind::NotSupported.into())
+                }
+                AsymmetricSignature::Ecdsa { hash_alg } => {
+                    if !matches!(
+                        attributes.key_type,
+                        Type::EccKeyPair {
+                            curve_family: EccFamily::SecpR1
+                        }
+                    ) {
+                        error!(
+                            "Signing key must use curve family SecpR1 for certificate requests."
+                        );
+                        return Err(ToolErrorKind::NotSupported.into());
+                    };
+
+                    match hash_alg {
+                        SignHash::Specific(Hash::Sha256) => {
+                            if attributes.bits == 256 {
+                                Ok(&PKCS_ECDSA_P256_SHA256)
+                            } else {
+                                error!("Signing key should have strength 256, but actually has strength {}.", attributes.bits);
+                                Err(ToolErrorKind::NotSupported.into())
+                            }
+                        }
+                        SignHash::Specific(Hash::Sha384) => {
+                            if attributes.bits == 384 {
+                                Ok(&PKCS_ECDSA_P384_SHA384)
+                            } else {
+                                error!("Signing key should have strength 384, but actually has strength {}.", attributes.bits);
+                                Err(ToolErrorKind::NotSupported.into())
+                            }
+                        }
+                        SignHash::Any => {
+                            match attributes.bits {
+                                256 => Ok(&PKCS_ECDSA_P256_SHA256),
+                                _ => {
+                                    // We have to fail this, because ParsecRemoteKeyPair::sign() defaults the hash to SHA-256, and RCGEN
+                                    // doesn't support a hash algorithm that is different from the key strength.
+                                    error!("Signing keys of strength other than 256-bit not supported without specific hash algorithm.");
+                                    Err(ToolErrorKind::NotSupported.into())
+                                }
+                            }
+                        }
+                        _ => {
+                            // The algorithm is specific, but not one that RCGEN can use, so fail the operation.
+                            error!("Signing key requires use of hashing algorithm ({:?}), which is not supported for certificate requests.", alg);
+                            Err(ToolErrorKind::NotSupported.into())
+                        }
+                    }
+                }
+                _ => {
+                    // Unsupported algorithm.
+                    error!("The specified key is not supported for certificate requests.");
+                    Err(ToolErrorKind::NotSupported.into())
+                }
+            }
+        } else {
+            error!("Specified key is not an asymmetric signing key, which is needed for certificate requests.");
+            Err(ToolErrorKind::WrongKeyAlgorithm.into())
+        }
+    }
+}
+
+impl RemoteKeyPair for ParsecRemoteKeyPair {
+    fn public_key(&self) -> &[u8] {
+        &self.public_key_der
+    }
+
+    fn sign(&self, msg: &[u8]) -> std::result::Result<Vec<u8>, RcgenError> {
+        let signature =
+            sign_message_with_policy(&self.parsec_client, &self.key_name, msg, Some(Hash::Sha256))
+                .map_err(RcgenError::from)?;
+        Ok(signature)
+    }
+
+    fn algorithm(&self) -> &'static SignatureAlgorithm {
+        self.rcgen_algorithm
+    }
+}
+
+impl From<Error> for RcgenError {
+    fn from(_e: Error) -> Self {
+        // There isn't a suitable mapping, because RcgenError does not have a variant for the
+        // case where RemoteKeyPair failed for third-party reasons.
+        // See: https://github.com/est31/rcgen/issues/67
+        // The crate will publish a new enum variant. When this change is released, we can rework this to be a
+        // more suitable error.
+        RcgenError::KeyGenerationUnavailable
+    }
+}

--- a/src/subcommands/create_csr.rs
+++ b/src/subcommands/create_csr.rs
@@ -82,10 +82,10 @@ impl CreateCsr {
 
         let parsec_key_pair = ParsecRemoteKeyPair {
             key_name: self.key_name.clone(),
-            public_key_der: public_key.clone(),
+            public_key_der: public_key,
             // "Move" the client into the struct here.
             parsec_client: basic_client,
-            rcgen_algorithm: rcgen_algorithm,
+            rcgen_algorithm,
         };
 
         let remote_key_pair = KeyPair::from_remote(Box::new(parsec_key_pair))?;

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -21,11 +21,11 @@ mod sign;
 
 use crate::error::{Error::ParsecClientError, Result};
 use crate::subcommands::{
-    create_ecc_key::CreateEccKey, create_rsa_key::CreateRsaKey, decrypt::Decrypt,
-    delete_client::DeleteClient, delete_key::DeleteKey, export_public_key::ExportPublicKey,
-    generate_random::GenerateRandom, list_authenticators::ListAuthenticators,
-    list_clients::ListClients, list_keys::ListKeys, list_opcodes::ListOpcodes,
-    list_providers::ListProviders, ping::Ping, sign::Sign, create_csr::CreateCsr,
+    create_csr::CreateCsr, create_ecc_key::CreateEccKey, create_rsa_key::CreateRsaKey,
+    decrypt::Decrypt, delete_client::DeleteClient, delete_key::DeleteKey,
+    export_public_key::ExportPublicKey, generate_random::GenerateRandom,
+    list_authenticators::ListAuthenticators, list_clients::ListClients, list_keys::ListKeys,
+    list_opcodes::ListOpcodes, list_providers::ListProviders, ping::Ping, sign::Sign,
 };
 use parsec_client::BasicClient;
 use structopt::StructOpt;

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -3,6 +3,7 @@
 
 //! Subcommand implementations. Interacts with parsec-client-rust.
 
+mod create_csr;
 mod create_ecc_key;
 mod create_rsa_key;
 mod decrypt;
@@ -24,7 +25,7 @@ use crate::subcommands::{
     delete_client::DeleteClient, delete_key::DeleteKey, export_public_key::ExportPublicKey,
     generate_random::GenerateRandom, list_authenticators::ListAuthenticators,
     list_clients::ListClients, list_keys::ListKeys, list_opcodes::ListOpcodes,
-    list_providers::ListProviders, ping::Ping, sign::Sign,
+    list_providers::ListProviders, ping::Ping, sign::Sign, create_csr::CreateCsr,
 };
 use parsec_client::BasicClient;
 use structopt::StructOpt;
@@ -73,6 +74,9 @@ pub enum Subcommand {
 
     /// Delete all data a client has in the service (admin operation).
     DeleteClient(DeleteClient),
+
+    /// Create a Certificate Signing Request (CSR) from a keypair.
+    CreateCsr(CreateCsr),
 }
 
 impl Subcommand {
@@ -93,6 +97,7 @@ impl Subcommand {
             Subcommand::Sign(cmd) => cmd.run(client),
             Subcommand::Decrypt(cmd) => cmd.run(client),
             Subcommand::DeleteKey(cmd) => cmd.run(client),
+            Subcommand::CreateCsr(cmd) => cmd.run(client),
         }
     }
     /// Indicates if subcommand requires authentication

--- a/src/subcommands/sign.rs
+++ b/src/subcommands/sign.rs
@@ -23,8 +23,12 @@ pub struct Sign {
 impl Sign {
     /// Signs data.
     pub fn run(&self, basic_client: BasicClient) -> Result<()> {
-        let signature =
-            sign_message_with_policy(&basic_client, &self.key_name, &self.input_data.as_bytes(), None)?;
+        let signature = sign_message_with_policy(
+            &basic_client,
+            &self.key_name,
+            self.input_data.as_bytes(),
+            None,
+        )?;
 
         let signature = base64::encode(&signature);
 

--- a/src/subcommands/sign.rs
+++ b/src/subcommands/sign.rs
@@ -5,13 +5,9 @@
 //!
 //! Will use the algorithm set to the key's policy during creation.
 
-use crate::error::{Result, ToolErrorKind};
-use log::{error, info};
-use parsec_client::core::interface::operations::psa_algorithm::{Algorithm, Hash, SignHash};
+use crate::error::Result;
+use crate::util::sign_message_with_policy;
 use parsec_client::BasicClient;
-use picky_asn1::wrapper::IntegerAsn1;
-use serde::{Deserialize, Serialize};
-use sha2::digest::{Digest, DynDigest};
 use structopt::StructOpt;
 
 /// Signs data.
@@ -24,50 +20,11 @@ pub struct Sign {
     input_data: String,
 }
 
-#[derive(Serialize, Deserialize)]
-struct EccSignature {
-    r: IntegerAsn1,
-    s: IntegerAsn1,
-}
-
 impl Sign {
     /// Signs data.
     pub fn run(&self, basic_client: BasicClient) -> Result<()> {
-        let alg = basic_client
-            .key_attributes(&self.key_name)?
-            .policy
-            .permitted_algorithms;
-
-        let signature = match alg {
-            Algorithm::AsymmetricSignature(alg) => {
-                let hash = match alg.hash() {
-                    Some(SignHash::Specific(hash)) => hash_data(self.input_data.as_bytes(), hash)?,
-                    _ => {
-                        error!("Asymmetric signing algorithm ({:?}) is not supported", alg);
-                        return Err(ToolErrorKind::NotSupported.into());
-                    }
-                };
-                info!("Signing data with {:?}...", alg);
-                let mut sig = basic_client.psa_sign_hash(&self.key_name, &hash, alg)?;
-                if alg.is_ecc_alg() {
-                    let s = IntegerAsn1::from_bytes_be_unsigned(sig.split_off(sig.len() / 2));
-                    sig = picky_asn1_der::to_vec(&EccSignature {
-                        r: IntegerAsn1::from_bytes_be_unsigned(sig),
-                        s,
-                    })
-                    .unwrap();
-                }
-
-                sig
-            }
-            other => {
-                error!(
-                    "Key's algorithm is {:?} which can not be used for signing.",
-                    other
-                );
-                return Err(ToolErrorKind::WrongKeyAlgorithm.into());
-            }
-        };
+        let signature =
+            sign_message_with_policy(&basic_client, &self.key_name, &self.input_data.as_bytes(), None)?;
 
         let signature = base64::encode(&signature);
 
@@ -75,20 +32,4 @@ impl Sign {
 
         Ok(())
     }
-}
-
-fn hash_data(data: &[u8], alg: Hash) -> Result<Vec<u8>> {
-    let mut hasher: Box<dyn DynDigest> = match alg {
-        Hash::Sha224 => Box::from(sha2::Sha224::new()),
-        Hash::Sha256 => Box::from(sha2::Sha256::new()),
-        Hash::Sha384 => Box::from(sha2::Sha384::new()),
-        Hash::Sha512 => Box::from(sha2::Sha512::new()),
-        _ => {
-            error!("Hashing algorithm ({:?}) not supported", alg);
-            return Err(ToolErrorKind::NotSupported.into());
-        }
-    };
-    info!("Hashing data with {:?}...", alg);
-    hasher.update(data);
-    Ok(hasher.finalize().to_vec())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,89 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utility code that is shared by multiple subcommands;
+
+use crate::error::{Result, ToolErrorKind};
+use log::{error, info};
+use parsec_client::core::interface::operations::psa_algorithm::{Algorithm, Hash, SignHash};
+use parsec_client::BasicClient;
+use picky_asn1::wrapper::IntegerAsn1;
+use serde::{Deserialize, Serialize};
+use sha2::digest::{Digest, DynDigest};
+
+#[derive(Serialize, Deserialize)]
+struct EccSignature {
+    r: IntegerAsn1,
+    s: IntegerAsn1,
+}
+
+/// Signs a given message using the hashing and signing policy that was associated with the given key when
+/// it was created.
+pub fn sign_message_with_policy(
+    basic_client: &BasicClient,
+    key_name: &String,
+    msg: &[u8],
+    default_hash: Option<Hash>,
+) -> Result<Vec<u8>> {
+    let alg = basic_client
+        .key_attributes(key_name)?
+        .policy
+        .permitted_algorithms;
+
+    let signature = match alg {
+        Algorithm::AsymmetricSignature(alg) => {
+            let hash = match alg.hash() {
+                Some(SignHash::Specific(hash)) => hash_data(msg, hash)?,
+                Some(SignHash::Any) => {
+                    if let Some(hash) = default_hash {
+                        hash_data(msg, hash)?
+                    } else {
+                        error!("Signing key allows any hashing algorithm, but no default was specified.");
+                        return Err(ToolErrorKind::NotSupported.into());
+                    }
+                }
+                _ => {
+                    error!("Asymmetric signing algorithm ({:?}) is not supported", alg);
+                    return Err(ToolErrorKind::NotSupported.into());
+                }
+            };
+            info!("Signing data with {:?}...", alg);
+            let mut sig = basic_client.psa_sign_hash(key_name, &hash, alg)?;
+            if alg.is_ecc_alg() {
+                let s = IntegerAsn1::from_bytes_be_unsigned(sig.split_off(sig.len() / 2));
+                sig = picky_asn1_der::to_vec(&EccSignature {
+                    r: IntegerAsn1::from_bytes_be_unsigned(sig),
+                    s,
+                })
+                .unwrap();
+            }
+
+            sig
+        }
+        other => {
+            error!(
+                "Key's algorithm is {:?} which can not be used for signing.",
+                other
+            );
+            return Err(ToolErrorKind::WrongKeyAlgorithm.into());
+        }
+    };
+
+    Ok(signature)
+}
+
+fn hash_data(data: &[u8], alg: Hash) -> Result<Vec<u8>> {
+    let mut hasher: Box<dyn DynDigest> = match alg {
+        Hash::Sha224 => Box::from(sha2::Sha224::new()),
+        Hash::Sha256 => Box::from(sha2::Sha256::new()),
+        Hash::Sha384 => Box::from(sha2::Sha384::new()),
+        Hash::Sha512 => Box::from(sha2::Sha512::new()),
+        _ => {
+            error!("Hashing algorithm ({:?}) not supported", alg);
+            return Err(ToolErrorKind::NotSupported.into());
+        }
+    };
+    info!("Hashing data with {:?}...", alg);
+    hasher.update(data);
+    Ok(hasher.finalize().to_vec())
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,9 +19,12 @@ struct EccSignature {
 
 /// Signs a given message using the hashing and signing policy that was associated with the given key when
 /// it was created.
+///
+/// If the signing key allows for the use of any hashing algorithm, then a default hash can optionally be passed
+/// by the caller, and this hash will be used (otherwise the function will fail).
 pub fn sign_message_with_policy(
     basic_client: &BasicClient,
-    key_name: &String,
+    key_name: &str,
     msg: &[u8],
     default_hash: Option<Hash>,
 ) -> Result<Vec<u8>> {

--- a/tests/parsec-cli-tests.sh
+++ b/tests/parsec-cli-tests.sh
@@ -129,7 +129,7 @@ test_ecc() {
         echo
         echo "- Using openssl and the exported public ECC key to verify the signature"
         # Parsec-tool produces base64-encoded signatures. Let's decode it before verifing.
-        run_cmd $OPENSSL base64 -d -in ${MY_TMP}/${KEY}.sign -out ${MY_TMP}/${KEY}.bin
+        run_cmd $OPENSSL base64 -d -a -A -in ${MY_TMP}/${KEY}.sign -out ${MY_TMP}/${KEY}.bin
 
         printf "$TEST_STR" >${MY_TMP}/${KEY}.test_str
         run_cmd $OPENSSL dgst -sha256 -verify ${MY_TMP}/${KEY}.pem \

--- a/tests/parsec-cli-tests.sh
+++ b/tests/parsec-cli-tests.sh
@@ -91,7 +91,7 @@ test_rsa() {
         echo "- Encrypting \"$TEST_STR\" string using openssl and the exported public key"
 
         # Encrypt TEST_STR with the public key and base64-encode the result
-        echo -n "$TEST_STR" >${MY_TMP}/${KEY}.test_str
+        printf "$TEST_STR" >${MY_TMP}/${KEY}.test_str
         run_cmd $OPENSSL rsautl -encrypt -pubin -inkey ${MY_TMP}/${KEY}.pem \
                                 -in ${MY_TMP}/${KEY}.test_str -out ${MY_TMP}/${KEY}.bin
         run_cmd $OPENSSL base64 -A -in ${MY_TMP}/${KEY}.bin -out ${MY_TMP}/${KEY}.enc
@@ -131,7 +131,7 @@ test_ecc() {
         # Parsec-tool produces base64-encoded signatures. Let's decode it before verifing.
         run_cmd $OPENSSL base64 -d -in ${MY_TMP}/${KEY}.sign -out ${MY_TMP}/${KEY}.bin
 
-        echo -n "$TEST_STR" >${MY_TMP}/${KEY}.test_str
+        printf "$TEST_STR" >${MY_TMP}/${KEY}.test_str
         run_cmd $OPENSSL dgst -sha256 -verify ${MY_TMP}/${KEY}.pem \
                               -signature ${MY_TMP}/${KEY}.bin ${MY_TMP}/${KEY}.test_str
     fi


### PR DESCRIPTION
- Refactors the majority of the `sign` command into a new `util` module so that it can be shared, because signing for a CSR is essentially the same operation.
- Introduce the `create-csr` command, which uses the `rcgen` crate (a new dependency with dual MIT/Apache-2 license)
- Fixes the CLI test script so that it works on MacOS as well as Linux, and adds a rudimentary test case for the new command, using `openssl` to check the validity of the certificate request document

Signed-off-by: Paul Howard <paul.howard@arm.com>
