### PR TITLE
Support the creation of RSA signing keys as well as encryption keys

### DIFF
--- a/src/subcommands/create_ecc_key.rs
+++ b/src/subcommands/create_ecc_key.rs
@@ -23,7 +23,7 @@ pub struct CreateEccKey {
 impl CreateEccKey {
     /// Exports a key.
     pub fn run(&self, basic_client: BasicClient) -> Result<()> {
-        info!("Creating ECC key...");
+        info!("Creating ECC signing key...");
 
         let attributes = Attributes {
             lifetime: Lifetime::Persistent,

--- a/src/subcommands/create_rsa_key.rs
+++ b/src/subcommands/create_rsa_key.rs
@@ -7,7 +7,9 @@
 
 use crate::error::Result;
 use log::info;
-use parsec_client::core::interface::operations::psa_algorithm::AsymmetricEncryption;
+use parsec_client::core::interface::operations::psa_algorithm::{
+    AsymmetricEncryption, AsymmetricSignature, Hash, SignHash,
+};
 use parsec_client::core::interface::operations::psa_key_attributes::{
     Attributes, Lifetime, Policy, Type, UsageFlags,
 };
@@ -19,25 +21,50 @@ use structopt::StructOpt;
 pub struct CreateRsaKey {
     #[structopt(short = "k", long = "key-name")]
     key_name: String,
+
+    /// This command creates RSA encryption keys by default. Supply this flag to create a signing key instead.
+    /// Signing keys, by default, will specify the SHA-256 hash algorithm and use PKCS#1 v1.5.
+    #[structopt(short = "s", long = "for-signing")]
+    is_for_signing: bool,
 }
 
 impl CreateRsaKey {
     /// Exports a key.
     pub fn run(&self, basic_client: BasicClient) -> Result<()> {
-        info!("Creating RSA key...");
-
-        let attributes = Attributes {
-            lifetime: Lifetime::Persistent,
-            key_type: Type::RsaKeyPair,
-            bits: 2048,
-            policy: Policy {
+        let policy = if self.is_for_signing {
+            info!("Creating RSA signing key...");
+            Policy {
+                usage_flags: {
+                    let mut usage_flags = UsageFlags::default();
+                    let _ = usage_flags
+                        .set_sign_hash()
+                        .set_verify_hash()
+                        .set_sign_message()
+                        .set_verify_message();
+                    usage_flags
+                },
+                permitted_algorithms: AsymmetricSignature::RsaPkcs1v15Sign {
+                    hash_alg: SignHash::Specific(Hash::Sha256),
+                }
+                .into(),
+            }
+        } else {
+            info!("Creating RSA encryption key...");
+            Policy {
                 usage_flags: {
                     let mut usage_flags = UsageFlags::default();
                     let _ = usage_flags.set_encrypt().set_decrypt();
                     usage_flags
                 },
                 permitted_algorithms: AsymmetricEncryption::RsaPkcs1v15Crypt.into(),
-            },
+            }
+        };
+
+        let attributes = Attributes {
+            lifetime: Lifetime::Persistent,
+            key_type: Type::RsaKeyPair,
+            bits: 2048,
+            policy,
         };
 
         basic_client.psa_generate_key(&self.key_name, attributes)?;


### PR DESCRIPTION
Use either `--for-signing` or `-s` on the command line to `create-rsa-key` in order to switch it over to creating a signing key.

Signed-off-by: Paul Howard <paul.howard@arm.com>