### PR TITLE
Update version of `rcgen` we use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
 
 [[package]]
 name = "libloading"
@@ -816,6 +816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c539a50b93a303167eded6e8dff5220cd39447409fb659f4cd24b1f72fe4f133"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1149,14 +1158,14 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rcgen"
-version = "0.8.14"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
+checksum = "d7fa2d386df8533b02184941c76ae2e0d0c1d053f5d43339169d80f21275fc5e"
 dependencies = [
- "chrono",
  "pem 1.0.1",
  "ring",
- "yasna 0.4.0",
+ "time 0.3.7",
+ "yasna 0.5.0",
 ]
 
 [[package]]
@@ -1513,6 +1522,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,11 +1784,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "chrono",
+ "time 0.3.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ picky-asn1-x509 = "0.6.1"
 serde = "1.0.123"
 sha2 = "0.9.9"
 log = "0.4.14"
-rcgen = { version = "0.8.14", features = ["pem"] }
+rcgen = { version = "0.9.2", features = ["pem"] }
 
 [lib]
 name = "parsec_tool"

--- a/src/subcommands/decrypt.rs
+++ b/src/subcommands/decrypt.rs
@@ -24,7 +24,7 @@ pub struct Decrypt {
 impl Decrypt {
     /// Decrypts data.
     pub fn run(&self, basic_client: BasicClient) -> Result<()> {
-        let input = base64::decode(self.input_data.as_bytes().to_vec())?;
+        let input = base64::decode(self.input_data.as_bytes())?;
 
         let alg = basic_client
             .key_attributes(&self.key_name)?


### PR DESCRIPTION
Catching up to date with the latest release of `rcgen`.

Also fixing a clippy lint issue.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>