### PR TITLE
Add an encrypt command plus tests.

### DIFF
--- a/src/subcommands/encrypt.rs
+++ b/src/subcommands/encrypt.rs
@@ -1,10 +1,13 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Encrypts data using a public key or the public part of a key pair.
+//! Encrypts some plaintext data with a specified key.
 //!
 //! Will use the algorithm set to the key's policy during creation. Currently only
-//! supports asymmetric encryption such as RSA.
+//! supports asymmetric encryption such as RSA, in which case the specified key must
+//! be a public key or an asymmetric key pair (of which the public part will be
+//! used). It is not possible to encrypt data using the private part of an asymmetric
+//! key pair. Encryption with symmetric keys will be added in the future.
 //!
 //! No salt is used.
 //!

--- a/src/subcommands/encrypt.rs
+++ b/src/subcommands/encrypt.rs
@@ -1,0 +1,68 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Encrypts data using a public key or the public part of a key pair.
+//!
+//! Will use the algorithm set to the key's policy during creation. Currently only
+//! supports asymmetric encryption such as RSA.
+//!
+//! No salt is used.
+//!
+//! The input is a plain text message string, which is treated as raw bytes.
+//!
+//! The output is base64-encoded ciphertext.
+
+use crate::error::{Result, ToolErrorKind};
+use log::{error, info};
+use parsec_client::core::interface::operations::psa_algorithm::Algorithm;
+use parsec_client::BasicClient;
+use structopt::StructOpt;
+
+/// Encrypts data.
+#[derive(Debug, StructOpt)]
+pub struct Encrypt {
+    #[structopt(short = "k", long = "key-name")]
+    key_name: String,
+
+    /// Plaintext input string.
+    input_data: String,
+}
+
+impl Encrypt {
+    /// Encrypts data.
+    pub fn run(&self, basic_client: BasicClient) -> Result<()> {
+        let input = self.input_data.as_bytes();
+
+        let alg = basic_client
+            .key_attributes(&self.key_name)?
+            .policy
+            .permitted_algorithms;
+
+        let ciphertext = match alg {
+            Algorithm::AsymmetricEncryption(alg) => {
+                info!("Encrypting data with {:?}...", alg);
+                basic_client.psa_asymmetric_encrypt(&self.key_name, alg, input, None)?
+            }
+            Algorithm::Cipher(_) | Algorithm::Aead(_) => {
+                error!(
+                    "Key's algorithm is {:?} which is not currently supported for encryption.",
+                    alg
+                );
+                return Err(ToolErrorKind::NotSupported.into());
+            }
+            other => {
+                error!(
+                    "Key's algorithm is {:?} which cannot be used for encryption.",
+                    other
+                );
+                return Err(ToolErrorKind::WrongKeyAlgorithm.into());
+            }
+        };
+
+        let ciphertext = base64::encode(&ciphertext);
+
+        println!("{}", ciphertext);
+
+        Ok(())
+    }
+}

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -9,6 +9,7 @@ mod create_rsa_key;
 mod decrypt;
 mod delete_client;
 mod delete_key;
+mod encrypt;
 mod export_public_key;
 mod generate_random;
 mod list_authenticators;
@@ -22,7 +23,7 @@ mod sign;
 use crate::error::{Error::ParsecClientError, Result};
 use crate::subcommands::{
     create_csr::CreateCsr, create_ecc_key::CreateEccKey, create_rsa_key::CreateRsaKey,
-    decrypt::Decrypt, delete_client::DeleteClient, delete_key::DeleteKey,
+    decrypt::Decrypt, delete_client::DeleteClient, delete_key::DeleteKey, encrypt::Encrypt,
     export_public_key::ExportPublicKey, generate_random::GenerateRandom,
     list_authenticators::ListAuthenticators, list_clients::ListClients, list_keys::ListKeys,
     list_opcodes::ListOpcodes, list_providers::ListProviders, ping::Ping, sign::Sign,
@@ -77,6 +78,9 @@ pub enum Subcommand {
 
     /// Create a Certificate Signing Request (CSR) from a keypair.
     CreateCsr(CreateCsr),
+
+    /// Encrypt data using the algorithm of the key
+    Encrypt(Encrypt),
 }
 
 impl Subcommand {
@@ -98,6 +102,7 @@ impl Subcommand {
             Subcommand::Decrypt(cmd) => cmd.run(client),
             Subcommand::DeleteKey(cmd) => cmd.run(client),
             Subcommand::CreateCsr(cmd) => cmd.run(client),
+            Subcommand::Encrypt(cmd) => cmd.run(client),
         }
     }
     /// Indicates if subcommand requires authentication


### PR DESCRIPTION
Makes it possible to use `parsec-tool` for encryption (with a public key or the public part of a key pair). The purpose of this is that it enables a use case where asymmetric encryption workflows can be round-tripped using only `parsec-tool` without any dependencies on third-party tools. This is useful for demonstration purposes.

The code is essentially a mirror-image of the existing `decrypt` command. It produces base64 output by default, which can be entered directly into `decrypt` to recover the original string.

Test case added to the CLI script. Note that the existing test_encryption function has been re-named to test_decryption, and I have introduced a new test_encryption function so that all of the nomenclature matches up.

Signed-off-by: Paul Howard <paul.howard@arm.com>