### PR TITLE
Update cargo audit configuration

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -22,9 +22,6 @@ show_tree = true # Show inverse dependency trees along with advisories
 [target]
 os = "linux" # Ignore advisories for operating systems other than this one
 
-[packages]
-source = "all" # "all", "public" or "local"
-
 [yanked]
 enabled = true # Warn for yanked crates in Cargo.lock
 update_index = true # Auto-update the crates.io index


### PR DESCRIPTION
The packages field is no longer used since https://github.com/rustsec/rustsec/pull/541

Also fixes the nightly CI :night_with_stars: 