### PR TITLE
Support a 'bits' argument for specifying the size/strength of RSA keys.

### DIFF
--- a/src/subcommands/create_rsa_key.rs
+++ b/src/subcommands/create_rsa_key.rs
@@ -26,6 +26,10 @@ pub struct CreateRsaKey {
     /// Signing keys, by default, will specify the SHA-256 hash algorithm and use PKCS#1 v1.5.
     #[structopt(short = "s", long = "for-signing")]
     is_for_signing: bool,
+
+    /// Specifies the size (strength) of the key in bits. The default size for RSA keys is 2048 bits.
+    #[structopt(short = "b", long = "bits")]
+    bits: Option<usize>,
 }
 
 impl CreateRsaKey {
@@ -63,7 +67,10 @@ impl CreateRsaKey {
         let attributes = Attributes {
             lifetime: Lifetime::Persistent,
             key_type: Type::RsaKeyPair,
-            bits: 2048,
+            // No prior validation of 'bits' argument. We have to let the service (and back-end hardware)
+            // decide what is valid. The PSA specification does not enforce any minimum/maximum/supported
+            // sizes for RSA keys.
+            bits: self.bits.unwrap_or(2048),
             policy,
         };
 

--- a/tests/parsec-cli-tests.sh
+++ b/tests/parsec-cli-tests.sh
@@ -86,6 +86,8 @@ test_crypto_provider() {
     test_signing "ECC"
     test_csr "RSA"
     test_csr "ECC"
+    test_rsa_key_default_bits
+    test_rsa_key_specific_bits
 }
 
 test_encryption() {
@@ -213,6 +215,30 @@ test_csr() {
     fi
 
     delete_key $1 $KEY
+}
+
+test_rsa_key_default_bits() {
+    KEY="anta-key-rsa-default-bits"
+    create_key "RSA" $KEY
+    run_cmd $PARSEC_TOOL_CMD export-public-key --key-name $KEY >${MY_TMP}/checksize-${KEY}.pem
+    run_cmd $OPENSSL rsa -pubin -text -noout -in ${MY_TMP}/checksize-${KEY}.pem >${MY_TMP}/checksize-${KEY}.txt
+    if ! cat ${MY_TMP}/checksize-${KEY}.txt | grep "RSA Public-Key: (2048 bit)"; then
+        echo "Error: create-rsa-key should have produced a 2048-bit RSA key by default."
+        EXIT_CODE=$(($EXIT_CODE+1))
+    fi
+    delete_key "RSA" $KEY
+}
+
+test_rsa_key_specific_bits() {
+    KEY="anta-key-rsa-specific-bits"
+    run_cmd $PARSEC_TOOL_CMD create-rsa-key --key-name $KEY --bits 1024
+    run_cmd $PARSEC_TOOL_CMD export-public-key --key-name $KEY >${MY_TMP}/checksize-${KEY}.pem
+    run_cmd $OPENSSL rsa -pubin -text -noout -in ${MY_TMP}/checksize-${KEY}.pem >${MY_TMP}/checksize-${KEY}.txt
+    if ! cat ${MY_TMP}/checksize-${KEY}.txt | grep "RSA Public-Key: (1024 bit)"; then
+        echo "Error: create-rsa-key should have produced a 1024-bit RSA key as specified."
+        EXIT_CODE=$(($EXIT_CODE+1))
+    fi
+    delete_key "RSA" $KEY
 }
 
 PARSEC_SERVICE_ENDPOINT="${PARSEC_SERVICE_ENDPOINT:-unix:/run/parsec/parsec.sock}"


### PR DESCRIPTION
Support a 'bits' argument for specifying the size/strength of RSA keys.
Signed-off-by: Paul Howard <paul.howard@arm.com>