### PR TITLE
Make RSA key string generic

### DIFF
--- a/tests/parsec-cli-tests.sh
+++ b/tests/parsec-cli-tests.sh
@@ -231,7 +231,7 @@ test_rsa_key_bits() {
     
     run_cmd $PARSEC_TOOL_CMD create-rsa-key --key-name $KEY $key_param
     run_cmd $PARSEC_TOOL_CMD export-public-key --key-name $KEY >${MY_TMP}/checksize-${KEY}.pem
-    if ! run_cmd $OPENSSL rsa -pubin -text -noout -in ${MY_TMP}/checksize-${KEY}.pem | grep -q "RSA Public-Key: (${key_size} bit)"; then
+    if ! run_cmd $OPENSSL rsa -pubin -text -noout -in ${MY_TMP}/checksize-${KEY}.pem | grep -q "Public-Key: (${key_size} bit)"; then
        echo "Error: create-rsa-key should have produced a ${key_size}-bit RSA key."
        EXIT_CODE=$(($EXIT_CODE+1))
     fi


### PR DESCRIPTION
Different OpenSSL versions provide different strings when the public key is exported. Some versions have 'RSA Public-Key' and some only 'Public-Key'. This commit changes the grepped string to make the test generic.

Closes #90 

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>