### PR TITLE
Update lib.rs to remove const_err

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 
 #![deny(
     nonstandard_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
This PR only removed `const_err` since it will be a hard error in future: https://github.com/rust-lang/rust/issues/71800