### PR TITLE
Track the main branch of the parsec-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,9 +555,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -777,16 +777,15 @@ dependencies = [
 [[package]]
 name = "parsec-client"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798ac04b102b074ad2a26976e53e4c918d2342ccb8ce6f31c2e71ab338b1156"
+source = "git+https://github.com/parallaxsecond/parsec-client-rust.git?branch=main#809bc15328f70cdd4c6c39130095ccfbb45c0722"
 dependencies = [
  "derivative",
+ "libc",
  "log",
  "num",
  "parsec-interface",
  "spiffe",
  "url",
- "users",
  "zeroize",
 ]
 
@@ -1437,16 +1436,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
-]
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/crate/parsec-tool"
 ansi_term = "0.12.1"
 atty = "0.2.14"
 clap = "2.34.0"
-parsec-client = "0.15.0"
+parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust.git", branch = "main" }
 structopt = "0.3.17"
 thiserror = "1.0.20"
 env_logger = "0.8.2"


### PR DESCRIPTION
Track the main branch of the parsec-client repository instead of tracking the crate release.
This will help avoid surprises when releasing.

Note: For the parsec-tool's release, the Cargo.toml file needs to be changed back so that versions are fixed.
Note 2: We should update the parsec-book release checklist accordingly