### PR TITLE
Add RSA_KEY_SIZE flag to cli test script

### DIFF
--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -32,3 +32,4 @@ fi
 ./target/debug/parsec-tool --help
 
 PARSEC_TOOL="./target/debug/parsec-tool" tests/parsec-cli-tests.sh -d
+PARSEC_TOOL="./target/debug/parsec-tool" tests/parsec-cli-tests.sh -d --rsa-key-size 1024


### PR DESCRIPTION
This flag can be used for testing parsec on slower platforms where RSA 2048 key operations are time consuming.

Closes #112

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>