### PR TITLE
Add dependency cross matching

### DIFF
--- a/.github/actions/ci_script/action.yml
+++ b/.github/actions/ci_script/action.yml
@@ -1,5 +1,10 @@
 name: "CI script Tests"
 description: "Install and run Parsec with the Mbed Crypto provider"
+inputs:
+    ci-flags:
+      required: true
+      default: ""
+      description: "Flags with which to run the ci.sh tests"
 
 runs:
   using: "composite"
@@ -12,5 +17,5 @@ runs:
         ./target/debug/parsec -c ../tests/test_config.toml &
       shell: bash
     - name: Execute CI script
-      run: ./tests/ci.sh
+      run: ./tests/ci.sh ${{ inputs.ci-flags }}
       shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,3 +42,20 @@ jobs:
         run: cargo install cargo-audit
       - name: Execute cargo audit
         run: cargo audit
+
+  mismatcher:
+    name: Check for mismatched dependencies (those that have more than one version)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Install Rust MSRV
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          rustflags: ""
+      - name: Execute CI script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "mismatcher"

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -5,9 +5,43 @@
 
 set -xeuf -o pipefail
 
+error_msg () {
+    echo "Error: $1"
+    exit 1
+}
+
 # Points to Parsec's Unix Domain Socket on the CI
 export PARSEC_SERVICE_ENDPOINT="unix:/tmp/parsec.sock"
 export RUST_LOG=error
+
+##################
+# Get Parameters #
+##################
+MISMATCHER=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        mismatcher )
+            MISMATCHER="True"
+        ;;
+        *)
+            error_msg "Unknown argument: $1"
+        ;;
+    esac
+    shift
+done
+
+#########################
+# Dependency mismatcher #
+#########################
+if [ "$MISMATCHER" = "True" ]; then
+    python3 $(pwd)/utils/dependency_cross_matcher.py --deps_dir $(pwd)
+    mismatcher_result=$?
+    if [ "$mismatcher_result" -ne 0 ]; then
+        error_msg "Found dependencies version mismatches"
+    fi
+
+    exit 0
+fi
 
 #########
 # Build #

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -1,0 +1,75 @@
+import argparse
+import re
+import os
+import subprocess
+import sys
+
+
+def run_cargo_tree(path):
+    cmd = 'cargo tree --all-features -d'
+    prev_dir = os.getcwd()
+    os.chdir(os.path.join(path))
+    return subprocess.check_output(cmd, shell=True).decode()
+
+
+def run_deps_mismatcher(lines):
+    pat = re.compile('([a-zA-Z]\S+)\s(v\S+)')
+    deps = dict()
+    for line in lines.split('\n'):
+        m = pat.search(line)
+        if m is not None:
+            if m.group(1) in deps.keys():
+                if m.group(2) not in deps[m.group(1)]:
+                    deps[m.group(1)].append(m.group(2))
+            else:
+                deps[m.group(1)] = [m.group(2)]
+    return deps
+
+
+def get_deps_with_more_than_1v(deps_and_versions):
+    new_dict = dict()
+    for dep_name, versions in deps_and_versions.items():
+        if len(versions) > 1:
+            new_dict[dep_name] = versions
+    return new_dict
+
+
+def print_deps(deps_and_versions):
+    for dep_name, versions in deps_and_versions.items():
+        print(f"{dep_name:<25} {versions}")
+
+
+def main(argv=[], prog_name=''):
+    parser = argparse.ArgumentParser(prog='DependencyCrossmatcher',
+                                     description='Checks the version mismatches for dependencies '
+                                                 'in Cargo based repositories')
+    parser.add_argument('--deps_dir',
+                        required=True,
+                        help='Existing directory that contains the Cargo.toml for analyzing'
+                             'dependencies')
+    args = parser.parse_args()
+
+    mismatches = run_deps_mismatcher(run_cargo_tree(args.deps_dir))
+    print_deps(mismatches)
+
+    mismatches = get_deps_with_more_than_1v(mismatches)
+
+    print('---------------------mistmatches----------------------\n\n')
+    print_deps(mismatches)
+
+    exceptions = {
+        'base64': ['v0.13.1', 'v0.21.4'],
+        'bitflags': ['v1.3.2', 'v2.4.1'],
+        'nom': ['v5.1.3', 'v7.1.3'],
+        'syn': ['v1.0.109', 'v2.0.38'],
+        'yasna': ['v0.4.0', 'v0.5.2'],
+    }
+
+    if exceptions != mismatches:
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:], sys.argv[0]))


### PR DESCRIPTION
- Add a script to check for mismatches in dependencies in the repository.
- Add a dependency mismatcher job that checks whether any dependencies have more than one versions.

Mismatches are two different versions of the same dependency.

This is based (almost a complete duplication) on what we currently have in Parsec:
https://github.com/parallaxsecond/parsec/pull/731