### PR TITLE
ci/nightly: Compare parsec and parsec-tool dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,20 @@ jobs:
         args: -v -r *.md
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}
+
+  mismatcher:
+    name: Check for mismatched dependencies (those that have more than one version)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Install latest Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          rustflags: ""
+      - name: Execute CI script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "mismatcher"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,20 +42,3 @@ jobs:
         run: cargo install cargo-audit
       - name: Execute cargo audit
         run: cargo audit
-
-  mismatcher:
-    name: Check for mismatched dependencies (those that have more than one version)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: "${{ github.event.inputs.rev }}"
-      - name: Install Rust MSRV
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          rustflags: ""
-      - name: Execute CI script
-        uses: ./.github/actions/ci_script
-        with:
-          ci-flags: "mismatcher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.19"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.1",
  "errno",

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -37,6 +37,8 @@ if [ "$MISMATCHER" = "True" ]; then
 
     python3 $(pwd)/utils/dependency_cross_matcher.py --deps_dir $(pwd)
 
+    python3 $(pwd)/utils/dependency_cross_matcher.py -c --deps_dir $(pwd)/parsec $(pwd)
+
     exit 0
 fi
 

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -34,7 +34,9 @@ done
 # Dependency mismatcher #
 #########################
 if [ "$MISMATCHER" = "True" ]; then
+
     python3 $(pwd)/utils/dependency_cross_matcher.py --deps_dir $(pwd)
+
     exit 0
 fi
 

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -35,11 +35,6 @@ done
 #########################
 if [ "$MISMATCHER" = "True" ]; then
     python3 $(pwd)/utils/dependency_cross_matcher.py --deps_dir $(pwd)
-    mismatcher_result=$?
-    if [ "$mismatcher_result" -ne 0 ]; then
-        error_msg "Found dependencies version mismatches"
-    fi
-
     exit 0
 fi
 

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -5,8 +5,10 @@ import subprocess
 import sys
 
 
-def run_cargo_tree(path):
-    cmd = 'cargo tree --all-features -d'
+def run_cargo_tree(path, flags=None):
+    cmd = 'cargo tree'
+    if flags is not None:
+        cmd += ' ' + flags
     prev_dir = os.getcwd()
     os.chdir(os.path.join(path))
     return subprocess.check_output(cmd, shell=True).decode()
@@ -43,14 +45,46 @@ def main(argv=[], prog_name=''):
     parser = argparse.ArgumentParser(prog='DependencyCrossmatcher',
                                      description='Checks the version mismatches for dependencies '
                                                  'in Cargo based repositories')
+    parser.add_argument("-c", "--compare", action='store_true',
+                        help='Check for mismatches between 2 repositories')
     parser.add_argument('--deps_dir',
                         required=True,
-                        help='Existing directory that contains the Cargo.toml for analyzing'
+                        nargs='+',
+                        help='Existing directories that contain Cargo.toml for analyzing '
                              'dependencies')
     args = parser.parse_args()
 
-    mismatches = run_deps_mismatcher(run_cargo_tree(args.deps_dir))
-    print_deps(mismatches)
+    mismatches = dict()
+    parsec_tool_flags = '--all-features -d'
+
+    if args.compare:
+        exceptions = {
+            'bindgen': ['v0.66.1', 'v0.57.0'],
+        }
+        parsec_repo, parsec_tool_repo = args.deps_dir
+        parsec_flags = '--all-features' + ' '
+        parsec_flags = '--features tss-esapi/generate-bindings,cryptoki/generate-bindings -d'
+        mismatches_parsec = run_deps_mismatcher(run_cargo_tree(parsec_repo, parsec_flags))
+        mismatches_parsec_tool = run_deps_mismatcher(run_cargo_tree(parsec_tool_repo,
+                                                                    parsec_tool_flags)
+                                                    )
+
+        # Dependencies that are common to both parsec_repo and parsec_tool_repo repos
+        common_deps = list(set(mismatches_parsec.keys()) & set(mismatches_parsec_tool.keys()))
+        for dep in common_deps:
+            # Symmetric difference of repos parsec_repo and parsec_tool_repo
+            mistmatch = list(set(mismatches_parsec[dep]) ^ set(mismatches_parsec_tool[dep]))
+            if len(mistmatch) > 0:
+                mismatches[dep] = mistmatch
+    else:
+        exceptions = {
+            'base64': ['v0.13.1', 'v0.21.4'],
+            'bitflags': ['v1.3.2', 'v2.4.1'],
+            'nom': ['v5.1.3', 'v7.1.3'],
+            'syn': ['v1.0.109', 'v2.0.38'],
+            'yasna': ['v0.4.0', 'v0.5.2'],
+        }
+        mismatches = run_deps_mismatcher(run_cargo_tree(args.deps_dir[0], parsec_tool_flags))
 
     mismatches = get_deps_with_more_than_1v(mismatches)
 
@@ -60,15 +94,12 @@ def main(argv=[], prog_name=''):
     print('---------------------mistmatches----------------------\n\n')
     print_deps(mismatches)
 
-    exceptions = {
-        'base64': ['v0.13.1', 'v0.21.4'],
-        'bitflags': ['v1.3.2', 'v2.4.1'],
-        'nom': ['v5.1.3', 'v7.1.3'],
-        'syn': ['v1.0.109', 'v2.0.38'],
-        'yasna': ['v0.4.0', 'v0.5.2'],
-    }
+    if not args.compare:
+        errormsg = "Found dependencies version mismatches in parsec-tool"
+    else:
+        errormsg = "Found dependencies version mismatches between parsec and parsec-tool"
 
-    assert exceptions == mismatches, "Found dependencies version mismatches in parsec-tool"
+    assert exceptions == mismatches, errormsg
 
     return 0
 

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -54,6 +54,9 @@ def main(argv=[], prog_name=''):
 
     mismatches = get_deps_with_more_than_1v(mismatches)
 
+    print('---------------------exceptions-----------------------\n\n')
+    print_deps(exceptions)
+
     print('---------------------mistmatches----------------------\n\n')
     print_deps(mismatches)
 
@@ -65,8 +68,7 @@ def main(argv=[], prog_name=''):
         'yasna': ['v0.4.0', 'v0.5.2'],
     }
 
-    if exceptions != mismatches:
-        return 1
+    assert exceptions == mismatches, "Found dependencies version mismatches in parsec-tool"
 
     return 0
 

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -1,3 +1,9 @@
+# Copyright 2023 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks the version mismatches for dependencies in Cargo based repositories:
+# * In parsec-tool itself
+# * Between parsec and parsec-tool
 import argparse
 import re
 import os


### PR DESCRIPTION
Depends on #115 . Please only review when this one is merged.

- Compare dependencies between parsec and parsec-tool to spot common dependencies that are being used with different versions.
- Incorporate a nightly check to test this

Closes https://github.com/parallaxsecond/parsec/issues/360