### PR TITLE
Track and test dependencies' 'test-next' branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,3 +42,20 @@ jobs:
         run: cargo install cargo-audit
       - name: Execute cargo audit
         run: cargo audit
+
+  build-next:
+    name: Execute CI script with next branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Install Rust MSRV
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.66.0
+          rustflags: ""
+      - name: Execute CI script with next branch
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "--test-next-branch-tracking"

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -18,10 +18,14 @@ export RUST_LOG=error
 # Get Parameters #
 ##################
 MISMATCHER=
+TEST_NEXT_BRANCH_TRACKING=
 while [ "$#" -gt 0 ]; do
     case "$1" in
         mismatcher )
             MISMATCHER="True"
+        ;;
+        --test-next-branch-tracking )
+            TEST_NEXT_BRANCH_TRACKING="True"
         ;;
         *)
             error_msg "Unknown argument: $1"
@@ -42,6 +46,13 @@ if [ "$MISMATCHER" = "True" ]; then
     exit 0
 fi
 
+#########################
+# Next branch tracking  #
+#########################
+if [ "$TEST_NEXT_BRANCH_TRACKING" ]; then
+    echo "Track next branches for parallaxsecond repositories"
+    python3 $(pwd)/parsec/utils/release_tracking.py $(pwd)/Cargo.toml
+fi
 #########
 # Build #
 #########


### PR DESCRIPTION
parsec-tool depends on several repositories under the parallaxsecond organization.

Currently, when testing the main branch of parsec, fixed versions of the latest released crates of those repositories are being used.
A problem may arise when there is a change introduced in the main/'test-next' branch of those repositories that would break parsec when updating/incorporating that change. This is currently not being tested in our CI.
As parsec-tool release is dependent on having published the dependencies' crates, there are issues that will not be caught until the publishing of said crates.

Add nightly jobs that use ci.sh --test-next-branch-tracking to test the next release branches of parallaxsecond repositories and spot issues before release. These jobs makes use of parsec's utils/release_tracking.py

Please see https://github.com/parallaxsecond/parsec/pull/732