### PR TITLE
ci: Ignore shlex report

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install cargo audit
         run: cargo install cargo-audit
       - name: Execute cargo audit
-        run: cargo audit
+        run: cargo audit --ignore RUSTSEC-2024-0006
 
   build-next:
     name: Execute CI script with next branch


### PR DESCRIPTION
shlex is currently only being brought by bindgen, which does not use the concerning APIs except for testing.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>