### PR TITLE
parsec-cli-tests.sh: Request expected CSR output format.

### DIFF
--- a/tests/parsec-cli-tests.sh
+++ b/tests/parsec-cli-tests.sh
@@ -228,10 +228,10 @@ test_csr() {
 
         echo
         echo "- Using openssl to inspect the CSR content and verify the public key."
-        run_cmd $OPENSSL req -text -noout -verify -in ${MY_TMP}/${KEY}.csr >${MY_TMP}/${KEY}.txt
+        run_cmd $OPENSSL req -text -nameopt utf8,space_eq -noout -verify -in ${MY_TMP}/${KEY}.csr >${MY_TMP}/${KEY}.txt
         debug cat ${MY_TMP}/${KEY}.txt
 
-        if ! cat ${MY_TMP}/${KEY}.txt | grep "Subject:" | grep -e "serialNumber = ${TEST_SERIAL}" -e "serialNumber=${TEST_SERIAL}"; then
+        if ! cat ${MY_TMP}/${KEY}.txt | grep "Subject:" | grep "serialNumber = ${TEST_SERIAL}"; then
             echo "Error: The CSR does not contain the serialNumber field of the Distinguished Name"
             EXIT_CODE=$(($EXIT_CODE+1))
         fi


### PR DESCRIPTION
OpenSSL 3.2 change the default format for subject and issuer. The obvious part is that a space is missing but the output also is now using UTF8.

To keep the format and simplify parsing, openssl can be taught which output format it should use. This is understood also by older openssl versions.

Use -nameopt to tell openssl to use UTF8 and a space which around `=' which is what the old parsing expected. Remove the conditional grep which was introduced to deal with the situation.