### PR TITLE
Cargo.toml: Temporary patch rcgen crate for RSA-PSS CSR support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
-*patch
 .devcontainer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,8 +1076,6 @@ dependencies = [
 [[package]]
 name = "rcgen"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,12 @@ sha2 = "0.9.9"
 log = "0.4.14"
 rcgen = { version = "0.9.2", features = ["pem"] }
 
+[package.metadata.patch]
+crates=["rcgen"]
+
+[patch.crates-io]
+rcgen = { path = './target/patch/rcgen-0.9.3' }
+
 [lib]
 name = "parsec_tool"
 path = "src/lib.rs"

--- a/patches/rcgen+0.9.3.patch
+++ b/patches/rcgen+0.9.3.patch
@@ -1,0 +1,58 @@
+diff --git a/src/lib.rs b/src/lib.rs
+index 565b3d6..23998c3 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1500,6 +1500,9 @@ impl KeyPair {
+ 		} else if alg == &PKCS_RSA_PSS_SHA256 {
+ 			let rsakp = RsaKeyPair::from_pkcs8(pkcs8)?;
+ 			KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA256)
++		} else if alg == &PKCS_RSA_PSS_SHA384 {
++			let rsakp = RsaKeyPair::from_pkcs8(pkcs8)?;
++			KeyPairKind::Rsa(rsakp, &signature::RSA_PSS_SHA384)
+ 		} else {
+ 			panic!("Unknown SignatureAlgorithm specified!");
+ 		};
+@@ -1886,6 +1889,7 @@ impl SignatureAlgorithm {
+ 			&PKCS_RSA_SHA384,
+ 			&PKCS_RSA_SHA512,
+ 			//&PKCS_RSA_PSS_SHA256,
++			//&PKCS_RSA_PSS_SHA384,
+ 			&PKCS_ECDSA_P256_SHA256,
+ 			&PKCS_ECDSA_P384_SHA384,
+ 			&PKCS_ED25519
+@@ -1938,17 +1942,32 @@ pub static PKCS_RSA_SHA512 :SignatureAlgorithm = SignatureAlgorithm {
+ // support those: https://github.com/briansmith/ring/issues/1353
+ //
+ /// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-256 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
+-static PKCS_RSA_PSS_SHA256 :SignatureAlgorithm = SignatureAlgorithm {
++pub static PKCS_RSA_PSS_SHA256 :SignatureAlgorithm = SignatureAlgorithm {
+ 	// We could also use OID_RSA_ENCRYPTION here, but it's recommended
+ 	// to use ID-RSASSA-PSS if possible.
+ 	oids_sign_alg :&[&OID_RSASSA_PSS],
+ 	sign_alg :SignAlgo::Rsa(),
+-	oid_components : &OID_RSASSA_PSS,//&[1, 2, 840, 113549, 1, 1, 13],
++	oid_components : &OID_RSASSA_PSS,//&[1, 2, 840, 113549, 1, 1, 11],
+ 	// rSASSA-PSS-SHA256-Params in RFC 4055
+ 	params : SignatureAlgorithmParams::RsaPss {
+ 		// id-sha256 in https://datatracker.ietf.org/doc/html/rfc4055#section-2.1
+ 		hash_algorithm : &[2, 16, 840, 1, 101, 3, 4, 2, 1],
+-		salt_length : 20,
++		salt_length : 32,
++	},
++};
++
++/// RSA signing with PKCS#1 2.1 RSASSA-PSS padding and SHA-384 hashing as per [RFC 4055](https://tools.ietf.org/html/rfc4055)
++pub static PKCS_RSA_PSS_SHA384 :SignatureAlgorithm = SignatureAlgorithm {
++	// We could also use OID_RSA_ENCRYPTION here, but it's recommended
++	// to use ID-RSASSA-PSS if possible.
++	oids_sign_alg :&[&OID_RSASSA_PSS],
++	sign_alg :SignAlgo::Rsa(),
++	oid_components : &OID_RSASSA_PSS,//&[1, 2, 840, 113549, 1, 1, 12],
++	// rSASSA-PSS-SHA384-Params in RFC 4055
++	params : SignatureAlgorithmParams::RsaPss {
++		// id-sha384 in https://datatracker.ietf.org/doc/html/rfc4055#section-2.1
++		hash_algorithm : &[2, 16, 840, 1, 101, 3, 4, 2, 2],
++		salt_length : 48,
+ 	},
+ };
+ 

--- a/src/subcommands/create_csr.rs
+++ b/src/subcommands/create_csr.rs
@@ -14,8 +14,8 @@ use parsec_client::core::interface::operations::psa_key_attributes::{EccFamily, 
 use parsec_client::BasicClient;
 use rcgen::{
     Certificate, CertificateParams, DistinguishedName, DnType, KeyPair, RcgenError, RemoteKeyPair,
-    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_RSA_SHA256,
-    PKCS_RSA_SHA384, PKCS_RSA_SHA512,
+    SignatureAlgorithm, PKCS_ECDSA_P256_SHA256, PKCS_ECDSA_P384_SHA384, PKCS_RSA_PSS_SHA256,
+    PKCS_RSA_PSS_SHA384, PKCS_RSA_SHA256, PKCS_RSA_SHA384, PKCS_RSA_SHA512,
 };
 
 /// Creates an X509 Certificate Signing Request (CSR) from a keypair, using the signing algorithm
@@ -183,10 +183,9 @@ impl CreateCsr {
                     Err(ToolErrorKind::NotSupported.into())
                 }
                 AsymmetricSignature::RsaPss { hash_alg } => match hash_alg {
-                    SignHash::Specific(Hash::Sha256) => Ok(&PKCS_RSA_SHA256),
-                    SignHash::Specific(Hash::Sha384) => Ok(&PKCS_RSA_SHA384),
-                    SignHash::Specific(Hash::Sha512) => Ok(&PKCS_RSA_SHA512),
-                    SignHash::Any => Ok(&PKCS_RSA_SHA256), // Default hash algorithm for the tool.
+                    SignHash::Specific(Hash::Sha256) => Ok(&PKCS_RSA_PSS_SHA256),
+                    SignHash::Specific(Hash::Sha384) => Ok(&PKCS_RSA_PSS_SHA384),
+                    SignHash::Any => Ok(&PKCS_RSA_PSS_SHA256), // Default hash algorithm for the tool.
                     _ => {
                         // The algorithm is specific, but not one that RCGEN can use, so fail the operation.
                         error!("Signing key requires use of hashing algorithm ({:?}), which is not supported for certificate requests.", alg);

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -14,6 +14,12 @@ error_msg () {
 export PARSEC_SERVICE_ENDPOINT="unix:/tmp/parsec.sock"
 export RUST_LOG=error
 
+#TODO: This applies the rcgen patch that exposes the PKCS_RSA_PSS_SHA256 and PKCS_RSA_PSS_SHA384 types. Remove this
+#      when the corresponding patch gets merged. Also remove rcgen+0.9.3.patch.
+rustup install 1.77.1 # We know that this version works for patch-crate
+cargo +1.77.1 install patch-crate --version 0.1.9
+cargo patch-crate
+
 ##################
 # Get Parameters #
 ##################
@@ -56,6 +62,7 @@ fi
 #########
 # Build #
 #########
+rustup --version
 RUST_BACKTRACE=1 cargo build
 RUST_BACKTRACE=1 cargo build --features spiffe-auth
 


### PR DESCRIPTION
RSA-PSS CSR creation functionality has been recently added.

For creating the CSRs, we are currently using rcgen.

For RSA-PSS, rcgen defined the PKCS_RSA_PSS_SHA256 type, which should be used instead of the currently used one (PKCS_RSA_SHA256).

Unfortunately, rcgen does not expose this type as there have been some issues validating the CSR creation of this type.

This has been tested using real RSA PSS keys and the functionality works as expected.

 * Patch rcgen to expose the PKCS_RSA_PSS_SHA256 type. The patch applies until these changes get fixed/merged upstream
       in rcgen.
 * Use this type in parsec-tool CSR creation for RSA-PSS.